### PR TITLE
Replace tick() usage with time()

### DIFF
--- a/demo_enhanced_memory_system.lua
+++ b/demo_enhanced_memory_system.lua
@@ -35,7 +35,7 @@ local function MockRobloxServices()
         end
     }
     
-    _G.tick = function() return os.time() end
+    _G.time = _G.time or os.time
     _G.wait = function() end
     _G.spawn = function(func) func() end
     _G.warn = function(...) print("WARN:", ...) end
@@ -111,14 +111,14 @@ local function RunEnhancedMemoryDemo()
     memoryManager.memoryUsage.SYSTEM_DATA = {
         current = 25 * 1024 * 1024, -- 25MB
         peak = 25 * 1024 * 1024,
-        lastUpdate = tick()
+        lastUpdate = time()
     }
     
     -- Add historical data showing normal growth
     memoryManager.memoryHistory.SYSTEM_DATA = {
-        { usage = 20 * 1024 * 1024, timestamp = tick() - 7200 }, -- 20MB 2 hours ago
-        { usage = 22 * 1024 * 1024, timestamp = tick() - 3600 }, -- 22MB 1 hour ago
-        { usage = 25 * 1024 * 1024, timestamp = tick() }         -- 25MB now
+        { usage = 20 * 1024 * 1024, timestamp = time() - 7200 }, -- 20MB 2 hours ago
+        { usage = 22 * 1024 * 1024, timestamp = time() - 3600 }, -- 22MB 1 hour ago
+        { usage = 25 * 1024 * 1024, timestamp = time() }         -- 25MB now
     }
     
     print("📈 Normal growth: 20MB → 22MB → 25MB (2.5MB/hour)")
@@ -130,7 +130,7 @@ local function RunEnhancedMemoryDemo()
     -- Add leak data
     table.insert(memoryManager.memoryHistory.SYSTEM_DATA, {
         usage = 100 * 1024 * 1024,
-        timestamp = tick()
+        timestamp = time()
     })
     
     print("📈 Leak detected: 25MB → 100MB (75MB sudden increase)")
@@ -151,7 +151,7 @@ local function RunEnhancedMemoryDemo()
     
     -- Add more historical data for better prediction
     print("📊 Adding historical data for prediction...")
-    local baseTime = tick() - 86400 -- 24 hours ago
+    local baseTime = time() - 86400 -- 24 hours ago
     for i = 1, 24 do
         local timeOffset = (i - 1) * 3600 -- 1 hour apart
         local usage = 15 * 1024 * 1024 + (i * 2 * 1024 * 1024) -- Growing usage
@@ -187,15 +187,15 @@ local function RunEnhancedMemoryDemo()
     memoryManager.memoryUsage.SECURITY_DATA = {
         current = 150 * 1024 * 1024, -- 150MB
         peak = 150 * 1024 * 1024,
-        lastUpdate = tick()
+        lastUpdate = time()
     }
     
     -- Add oscillating pattern (potential attack)
     memoryManager.memoryHistory.SECURITY_DATA = {
-        { usage = 50 * 1024 * 1024, timestamp = tick() - 900 },  -- 50MB 15 min ago
-        { usage = 200 * 1024 * 1024, timestamp = tick() - 600 }, -- 200MB 10 min ago
-        { usage = 100 * 1024 * 1024, timestamp = tick() - 300 }, -- 100MB 5 min ago
-        { usage = 150 * 1024 * 1024, timestamp = tick() }        -- 150MB now
+        { usage = 50 * 1024 * 1024, timestamp = time() - 900 },  -- 50MB 15 min ago
+        { usage = 200 * 1024 * 1024, timestamp = time() - 600 }, -- 200MB 10 min ago
+        { usage = 100 * 1024 * 1024, timestamp = time() - 300 }, -- 100MB 5 min ago
+        { usage = 150 * 1024 * 1024, timestamp = time() }        -- 150MB now
     }
     
     print("📊 Oscillating pattern: 50MB → 200MB → 100MB → 150MB")

--- a/src/Client/MainClient.lua
+++ b/src/Client/MainClient.lua
@@ -117,7 +117,7 @@ end
 
 -- NEW: Enhanced performance monitoring methods (Roblox best practice)
 function MainClient:UpdatePerformanceMetrics()
-    local currentTime = tick()
+    local currentTime = time()
     local updateTime = currentTime - performanceMetrics.lastUpdate
     
     -- Track update times for averaging
@@ -262,7 +262,7 @@ function MainClient:Initialize()
     print("Initializing Client - Milestone 3: Advanced Competitive & Social Systems...")
     
     -- NEW: Performance monitoring start (Roblox best practice)
-    performanceMetrics.lastUpdate = tick()
+    performanceMetrics.lastUpdate = time()
     
     -- Wait for player to load
     if not clientState.player then
@@ -1544,7 +1544,7 @@ end
 
 function MainClient:TakeMemorySnapshot()
     return {
-        timestamp = tick(),
+        timestamp = time(),
         memoryUsage = performanceMetrics.memoryUsage,
         systemHealth = performanceMetrics.systemHealth
     }

--- a/src/Competitive/CompetitiveManager.lua
+++ b/src/Competitive/CompetitiveManager.lua
@@ -92,7 +92,7 @@ function CompetitiveManager.new()
     
     -- Season management
     self.currentSeason = 1
-    self.seasonStartTime = tick()
+    self.seasonStartTime = time()
     self.seasonDuration = 30 * 24 * 60 * 60 -- 30 days in seconds
     
     -- Initialize anime-specific systems
@@ -281,7 +281,7 @@ end
 
 -- Initialize anime seasonal events
 function CompetitiveManager:InitializeAnimeSeasonalEvents()
-    local currentTime = tick()
+    local currentTime = time()
     
     -- Create seasonal events for each anime theme
     for _, animeTheme in ipairs(self.animeLeaderboardCategories) do
@@ -321,8 +321,8 @@ function CompetitiveManager:InitializeCrossAnimeTournaments()
             participants = {},
             brackets = {},
             status = "Registration",
-            startTime = tick(),
-            endTime = tick() + (7 * 24 * 60 * 60), -- 7 days
+            startTime = time(),
+            endTime = time() + (7 * 24 * 60 * 60), -- 7 days
             rewards = {
                 first = { points = 1000, currency = "Universal", amount = 5000 },
                 second = { points = 500, currency = "Universal", amount = 2500 },
@@ -477,7 +477,7 @@ end
 
 -- Get season metrics
 function CompetitiveManager:GetSeasonMetrics()
-    local currentTime = tick()
+    local currentTime = time()
     local timeInSeason = currentTime - self.seasonStartTime
     local seasonProgress = math.min(timeInSeason / self.seasonDuration, 1)
     
@@ -569,7 +569,7 @@ end
 function CompetitiveManager:StartUpdateLoop()
     -- Update leaderboards and check season status
     RunService.Heartbeat:Connect(function()
-        local currentTime = tick()
+        local currentTime = time()
         
         -- Check if season should reset
         if currentTime - self.seasonStartTime >= self.seasonDuration then
@@ -605,7 +605,7 @@ function CompetitiveManager:UpdateLeaderboard(category, playerData)
         playerId = playerId,
         playerName = playerData.playerName,
         value = playerData.value or 0,
-        lastUpdate = tick(),
+        lastUpdate = time(),
         metadata = playerData.metadata or {}
     }
     
@@ -676,7 +676,7 @@ function CompetitiveManager:ProcessSeasonalReset()
     
     -- Reset seasonal data
     self.currentSeason = self.currentSeason + 1
-    self.seasonStartTime = tick()
+    self.seasonStartTime = time()
     
     -- Clear seasonal rankings
     for category, leaderboard in pairs(self.leaderboards) do
@@ -719,7 +719,7 @@ function CompetitiveManager:AwardAchievement(player, achievementId)
     
     -- Award achievement
     self.achievements[userId][achievementId] = {
-        unlockedAt = tick(),
+        unlockedAt = time(),
         points = achievement.points,
         category = achievement.category
     }
@@ -864,7 +864,7 @@ function CompetitiveManager:CheckPrestigeUpgrade(userId, points)
         end
         
         self.prestigeData[userId].tier = newTier
-        self.prestigeData[userId].upgradedAt = tick()
+        self.prestigeData[userId].upgradedAt = time()
         
         print("CompetitiveManager: Player", userId, "upgraded to", newTier.name, "tier!")
         
@@ -1030,7 +1030,7 @@ function CompetitiveManager:GrantItemToPlayer(player, itemId, quantity)
 end
 
 function CompetitiveManager:GetSeasonProgress(userId)
-    local currentTime = tick()
+    local currentTime = time()
     local seasonProgress = (currentTime - self.seasonStartTime) / self.seasonDuration
     
     return math.min(1, math.max(0, seasonProgress))
@@ -1041,7 +1041,7 @@ end
 -- Start a character battle between two players
 function CompetitiveManager:StartCharacterBattle(player1, player2, animeTheme, battleType)
     local battleId = HttpService:GenerateGUID(false)
-    local currentTime = tick()
+    local currentTime = time()
     
     local battle = {
         id = battleId,
@@ -1080,7 +1080,7 @@ function CompetitiveManager:ProcessBattleRound(battleId, roundData)
         player1Action = roundData.player1Action,
         player2Action = roundData.player2Action,
         winner = roundData.winner,
-        timestamp = tick()
+        timestamp = time()
     }
     
     table.insert(battle.rounds, round)
@@ -1089,7 +1089,7 @@ function CompetitiveManager:ProcessBattleRound(battleId, roundData)
     if #battle.rounds >= 3 or roundData.winner then
         battle.status = "Completed"
         battle.winner = roundData.winner
-        battle.endTime = tick()
+        battle.endTime = time()
         
         -- Process battle completion
         self:CompleteCharacterBattle(battle)
@@ -1233,7 +1233,7 @@ end
 -- Create theme-specific challenge
 function CompetitiveManager:CreateThemeChallenge(animeTheme, challengeType, challengeData)
     local challengeId = HttpService:GenerateGUID(false)
-    local currentTime = tick()
+    local currentTime = time()
     
     local challenge = {
         id = challengeId,
@@ -1290,7 +1290,7 @@ function CompetitiveManager:JoinThemeChallenge(player, challengeId)
     -- Add player to challenge
     challenge.participants[userId] = {
         playerName = player.Name,
-        joinTime = tick(),
+        joinTime = time(),
         progress = 0,
         completed = false
     }
@@ -1299,7 +1299,7 @@ function CompetitiveManager:JoinThemeChallenge(player, challengeId)
     challenge.leaderboard[userId] = {
         playerName = player.Name,
         progress = 0,
-        lastUpdate = tick()
+        lastUpdate = time()
     }
     
     print("CompetitiveManager: Player", player.Name, "joined challenge:", challenge.title)
@@ -1319,12 +1319,12 @@ function CompetitiveManager:UpdateChallengeProgress(player, challengeId, progres
     -- Update progress
     participant.progress = math.max(participant.progress, progress)
     challenge.leaderboard[userId].progress = participant.progress
-    challenge.leaderboard[userId].lastUpdate = tick()
+    challenge.leaderboard[userId].lastUpdate = time()
     
     -- Check if challenge completed
     if participant.progress >= 100 and not participant.completed then
         participant.completed = true
-        participant.completionTime = tick()
+        participant.completionTime = time()
         
         -- Award completion rewards
         self:GrantChallengeRewards(player, challenge)
@@ -1449,7 +1449,7 @@ function CompetitiveManager:CheckChallengeCompletion(challenge)
     end
     
     -- End challenge if all participants completed or time expired
-    if completedCount >= totalParticipants or tick() >= challenge.endTime then
+    if completedCount >= totalParticipants or time() >= challenge.endTime then
         challenge.status = "Completed"
         self:EndThemeChallenge(challenge)
     end
@@ -1914,7 +1914,7 @@ function CompetitiveManager:UpdateAllLeaderboards()
     
     -- Get all online players
     local players = Players:GetPlayers()
-    local currentTime = tick()
+    local currentTime = time()
     
     -- Update each leaderboard category
     for category, leaderboard in pairs(self.leaderboards) do
@@ -2153,7 +2153,7 @@ function CompetitiveManager:GetCurrentSeason()
         number = self.currentSeason,
         startTime = self.seasonStartTime,
         duration = self.seasonDuration,
-        progress = (tick() - self.seasonStartTime) / self.seasonDuration
+        progress = (time() - self.seasonStartTime) / self.seasonDuration
     }
 end
 
@@ -2292,7 +2292,7 @@ function CompetitiveManager:JoinTournament(player, tournamentId)
     -- Add player to tournament
     tournament.participants[userId] = {
         playerName = player.Name,
-        joinTime = tick(),
+        joinTime = time(),
         theme = self:GetPlayerPrimaryTheme(userId),
         status = "Active"
     }
@@ -2419,7 +2419,7 @@ end
 
 -- Initialize anime ranking seasons
 function CompetitiveManager:InitializeAnimeRankingSeasons()
-    local currentTime = tick()
+    local currentTime = time()
     
     -- Create ranking seasons for each anime theme
     for _, animeTheme in ipairs(self.animeLeaderboardCategories) do
@@ -2492,8 +2492,8 @@ function CompetitiveManager:InitializeAnimeSeasonalChallenges()
             objectives = {},
             rewards = {},
             participants = {},
-            startTime = tick(),
-            endTime = tick() + self.seasonDuration,
+            startTime = time(),
+            endTime = time() + self.seasonDuration,
             status = "Active"
         }
     end
@@ -2712,7 +2712,7 @@ end
 -- Start a fusion battle between characters
 function CompetitiveManager:StartFusionBattle(player1, player2, animeTheme, fusionType)
     local fusionId = HttpService:GenerateGUID(false)
-    local currentTime = tick()
+    local currentTime = time()
     
     local fusion = {
         id = fusionId,
@@ -2749,7 +2749,7 @@ function CompetitiveManager:ProcessFusionBattle(fusionId, fusionData)
     if fusion.fusionProgress >= 100 then
         fusion.status = "Completed"
         fusion.winner = fusionData.winner or fusion.player1
-        fusion.endTime = tick()
+        fusion.endTime = time()
         
         -- Process fusion completion
         self:CompleteFusionBattle(fusion)
@@ -2892,7 +2892,7 @@ end
 -- Create seasonal anime challenge
 function CompetitiveManager:CreateSeasonalAnimeChallenge(animeTheme, challengeData)
     local challengeId = HttpService:GenerateGUID(false)
-    local currentTime = tick()
+    local currentTime = time()
     
     local challenge = {
         id = challengeId,
@@ -2934,7 +2934,7 @@ function CompetitiveManager:JoinSeasonalAnimeChallenge(player, challengeId)
     -- Add player to challenge
     challenge.participants[userId] = {
         playerName = player.Name,
-        joinTime = tick(),
+        joinTime = time(),
         progress = 0,
         objectives = {},
         completed = false
@@ -2975,7 +2975,7 @@ function CompetitiveManager:UpdateSeasonalChallengeProgress(player, challengeId,
     -- Check if challenge completed
     if participant.progress >= 100 and not participant.completed then
         participant.completed = true
-        participant.completionTime = tick()
+        participant.completionTime = time()
         
         -- Award completion rewards
         self:GrantSeasonalChallengeRewards(player, challenge)
@@ -3016,7 +3016,7 @@ end
 -- Start anime guild war
 function CompetitiveManager:StartAnimeGuildWar(guild1, guild2, warType, animeTheme)
     local warId = HttpService:GenerateGUID(false)
-    local currentTime = tick()
+    local currentTime = time()
     
     local war = {
         id = warId,
@@ -3054,7 +3054,7 @@ function CompetitiveManager:ProcessGuildWarBattle(warId, battleData)
         player1 = battleData.player1,
         player2 = battleData.player2,
         winner = battleData.winner,
-        timestamp = tick()
+        timestamp = time()
     }
     
     table.insert(war.battles, battle)
@@ -3067,7 +3067,7 @@ function CompetitiveManager:ProcessGuildWarBattle(warId, battleData)
     end
     
     -- Check if war should end
-    if #war.battles >= 10 or (tick() - war.startTime) >= war.duration then
+    if #war.battles >= 10 or (time() - war.startTime) >= war.duration then
         self:EndGuildWar(war)
     end
     
@@ -3085,7 +3085,7 @@ function CompetitiveManager:EndGuildWar(war)
     end
     
     war.status = "Completed"
-    war.endTime = tick()
+    war.endTime = time()
     
     -- Award war rewards
     self:AwardGuildWarRewards(war)

--- a/src/Competitive/GuildSystem.lua
+++ b/src/Competitive/GuildSystem.lua
@@ -568,7 +568,7 @@ function GuildSystem:HandlePlayerJoined(player)
         if guild then
             -- Update member's last active time
             if guild.members[userId] then
-                guild.members[userId].lastActive = tick()
+                guild.members[userId].lastActive = time()
             end
             
             -- Broadcast player rejoined
@@ -588,7 +588,7 @@ function GuildSystem:HandlePlayerLeaving(player)
         if guild then
             -- Update member's last active time
             if guild.members[userId] then
-                guild.members[userId].lastActive = tick()
+                guild.members[userId].lastActive = time()
             end
             
             -- Broadcast player leaving
@@ -601,7 +601,7 @@ end
 
 -- Guild update functions
 function GuildSystem:UpdateAllGuilds()
-    local currentTime = tick()
+    local currentTime = time()
     
     for guildId, guild in pairs(self.guilds) do
         -- Update guild experience and level
@@ -656,7 +656,7 @@ end
 function GuildSystem:StartUpdateLoop()
     -- Update guilds and process events
     RunService.Heartbeat:Connect(function()
-        local currentTime = tick()
+        local currentTime = time()
         
         -- Process guild updates
         if currentTime % self.guildUpdateInterval < 0.1 then
@@ -720,17 +720,17 @@ function GuildSystem:CreateGuild(leader, guildName, description, tag)
         leader = userId,
         members = {[userId] = {
             role = "LEADER",
-            joinedAt = tick(),
+            joinedAt = time(),
             contribution = 0,
-            lastActive = tick()
+            lastActive = time()
         }},
         level = 1,
         experience = 0,
         experienceToNext = self:CalculateExperienceToNext(1),
         treasury = 0,
         upgrades = {"GUILD_CHAT", "BASIC_BONUSES"},
-        createdAt = tick(),
-        lastActive = tick(),
+        createdAt = time(),
+        lastActive = time(),
         settings = {
             autoAccept = false,
             minLevel = 1,
@@ -853,8 +853,8 @@ function GuildSystem:ActivateAnimeGuildBonus(guildId, bonusId, activator)
     
     -- Check if bonus is on cooldown
     local currentBonus = self.animeGuildBonuses[guildId] and self.animeGuildBonuses[guildId][bonusId]
-    if currentBonus and tick() < currentBonus.expiresAt + bonus.cooldown then
-        local remainingCooldown = (currentBonus.expiresAt + bonus.cooldown) - tick()
+    if currentBonus and time() < currentBonus.expiresAt + bonus.cooldown then
+        local remainingCooldown = (currentBonus.expiresAt + bonus.cooldown) - time()
         return false, "Bonus on cooldown. Remaining time: " .. math.floor(remainingCooldown / 60) .. " minutes"
     end
     
@@ -866,8 +866,8 @@ function GuildSystem:ActivateAnimeGuildBonus(guildId, bonusId, activator)
     self.animeGuildBonuses[guildId][bonusId] = {
         effect = bonus.effect,
         value = bonus.value,
-        activatedAt = tick(),
-        expiresAt = tick() + bonus.duration,
+        activatedAt = time(),
+        expiresAt = time() + bonus.duration,
         activatorId = activatorId
     }
     
@@ -943,7 +943,7 @@ function GuildSystem:StartAnimeGuildWar(guild1Id, guild2Id, initiator)
         guild2Id = guild2Id,
         guild1Theme = guild1.animeTheme,
         guild2Theme = guild2.animeTheme,
-        startTime = tick(),
+        startTime = time(),
         duration = 7 * 24 * 60 * 60, -- 7 days
         status = "ACTIVE",
         warType = "ANIME_WAR",
@@ -1018,7 +1018,7 @@ function GuildSystem:AreGuildsAtAnimeWar(guild1Id, guild2Id)
 end
 
 function GuildSystem:ProcessAnimeGuildWars()
-    local currentTime = tick()
+    local currentTime = time()
     
     for warId, war in pairs(self.animeGuildWars) do
         if war.status == "ACTIVE" and war.warType == "ANIME_WAR" then
@@ -1039,7 +1039,7 @@ function GuildSystem:ProcessAnimeWarEvents(warId)
         return
     end
     
-    local currentTime = tick()
+    local currentTime = time()
     
     -- Generate random anime war events
     if currentTime % 3600 < 0.1 then -- Every hour
@@ -1073,8 +1073,8 @@ function GuildSystem:GenerateAnimeWarEvent(warId)
     local event = {
         id = eventId,
         type = eventType,
-        startTime = tick(),
-        expiresAt = tick() + 1800, -- 30 minutes
+        startTime = time(),
+        expiresAt = time() + 1800, -- 30 minutes
         status = "ACTIVE",
         participants = {},
         rewards = self:CalculateAnimeWarEventRewards(eventType)
@@ -1165,7 +1165,7 @@ function GuildSystem:EndAnimeGuildWar(warId)
     -- Update war status
     war.status = "COMPLETED"
     war.winner = winnerId
-    war.endTime = tick()
+    war.endTime = time()
     
     -- Award anime war rewards
     self:AwardAnimeWarRewards(warId, winnerId, loserId)
@@ -1274,7 +1274,7 @@ function GuildSystem:CreateCrossAnimeCollaboration(guild1Id, guild2Id, collabora
         guild1Theme = guild1.animeTheme,
         guild2Theme = guild2.animeTheme,
         type = collaborationType,
-        startTime = tick(),
+        startTime = time(),
         duration = 3 * 24 * 60 * 60, -- 3 days
         status = "ACTIVE",
         participants = {
@@ -1301,7 +1301,7 @@ function GuildSystem:CreateCrossAnimeCollaboration(guild1Id, guild2Id, collabora
 end
 
 function GuildSystem:ProcessCrossAnimeCollaborations()
-    local currentTime = tick()
+    local currentTime = time()
     
     for collabId, collab in pairs(self.crossAnimeCollaborations) do
         if collab.status == "ACTIVE" then
@@ -1338,8 +1338,8 @@ function GuildSystem:GenerateCrossAnimeCollaborationEvent(collaborationId)
     local event = {
         id = eventId,
         type = eventType,
-        startTime = tick(),
-        expiresAt = tick() + 1800, -- 30 minutes
+        startTime = time(),
+        expiresAt = time() + 1800, -- 30 minutes
         status = "ACTIVE",
         participants = {},
         rewards = self:CalculateCrossAnimeCollaborationEventRewards(eventType)
@@ -1388,7 +1388,7 @@ function GuildSystem:EndCrossAnimeCollaboration(collaborationId)
     
     -- Update status
     collab.status = "COMPLETED"
-    collab.endTime = tick()
+    collab.endTime = time()
     
     -- Award rewards to both guilds
     self:AwardCrossAnimeCollaborationRewards(collaborationId)
@@ -1457,7 +1457,7 @@ function GuildSystem:CreateAnimeFestival(guildId, festivalType, data, creator)
         type = festivalType,
         data = data,
         creatorId = creator.UserId,
-        startTime = tick(),
+        startTime = time(),
         duration = 24 * 60 * 60, -- 24 hours
         status = "ACTIVE",
         participants = {},
@@ -1481,7 +1481,7 @@ function GuildSystem:CreateAnimeFestival(guildId, festivalType, data, creator)
 end
 
 function GuildSystem:ProcessAnimeFestivals()
-    local currentTime = tick()
+    local currentTime = time()
     
     for festivalId, festival in pairs(self.animeFestivals) do
         if festival.status == "ACTIVE" then
@@ -1518,8 +1518,8 @@ function GuildSystem:GenerateAnimeFestivalEvent(festivalId)
     local event = {
         id = eventId,
         type = eventType,
-        startTime = tick(),
-        expiresAt = tick() + 900, -- 15 minutes
+        startTime = time(),
+        expiresAt = time() + 900, -- 15 minutes
         status = "ACTIVE",
         participants = {},
         rewards = self:CalculateAnimeFestivalEventRewards(eventType)
@@ -1567,7 +1567,7 @@ function GuildSystem:EndAnimeFestival(festivalId)
     
     -- Update status
     festival.status = "COMPLETED"
-    festival.endTime = tick()
+    festival.endTime = time()
     
     -- Award rewards to guild
     self:AwardAnimeFestivalRewards(festivalId)
@@ -1654,9 +1654,9 @@ function GuildSystem:AddGuildMember(guildId, player, role)
     -- Add member
     guild.members[userId] = {
         role = role or "MEMBER",
-        joinedAt = tick(),
+        joinedAt = time(),
         contribution = 0,
-        lastActive = tick()
+        lastActive = time()
     }
     
     self.playerGuilds[userId] = guildId
@@ -1858,7 +1858,7 @@ function GuildSystem:SendGuildChat(player, guildId, message)
         playerId = userId,
         playerName = player.Name,
         message = message,
-        timestamp = tick()
+        timestamp = time()
     })
     
     return true
@@ -1895,8 +1895,8 @@ function GuildSystem:SendGuildInvite(sender, targetPlayer, guildId)
         senderId = senderId,
         senderName = sender.Name,
         targetId = targetId,
-        timestamp = tick(),
-        expiresAt = tick() + 24 * 60 * 60 -- 24 hours
+        timestamp = time(),
+        expiresAt = time() + 24 * 60 * 60 -- 24 hours
     }
     
     -- Store invite
@@ -1926,7 +1926,7 @@ function GuildSystem:AcceptGuildInvite(player, inviteId)
     end
     
     -- Check if invite expired
-    if tick() > invite.expiresAt then
+    if time() > invite.expiresAt then
         table.remove(invites, inviteId)
         return false, "Invite has expired"
     end
@@ -1965,7 +1965,7 @@ function GuildSystem:SubmitGuildApplication(player, guildId, message)
         playerId = userId,
         playerName = player.Name,
         message = message,
-        timestamp = tick(),
+        timestamp = time(),
         status = "PENDING"
     }
     
@@ -2013,7 +2013,7 @@ function GuildSystem:StartGuildWar(guild1Id, guild2Id, initiator)
         id = warId,
         guild1Id = guild1Id,
         guild2Id = guild2Id,
-        startTime = tick(),
+        startTime = time(),
         duration = 7 * 24 * 60 * 60, -- 7 days
         status = "ACTIVE",
         scores = {
@@ -2038,7 +2038,7 @@ function GuildSystem:StartGuildWar(guild1Id, guild2Id, initiator)
 end
 
 function GuildSystem:ProcessGuildWars()
-    local currentTime = tick()
+    local currentTime = time()
     
     for warId, war in pairs(self.guildWars) do
         if war.status == "ACTIVE" then
@@ -2063,7 +2063,7 @@ function GuildSystem:EndGuildWar(warId)
     -- Update war status
     war.status = "COMPLETED"
     war.winner = winnerId
-    war.endTime = tick()
+    war.endTime = time()
     
     -- Award rewards
     self:AwardWarRewards(warId, winnerId, loserId)
@@ -2103,7 +2103,7 @@ function GuildSystem:CreateGuildEvent(guildId, eventType, data, creator)
         type = eventType,
         data = data,
         creatorId = creatorId,
-        startTime = tick(),
+        startTime = time(),
         status = "ACTIVE",
         participants = {}
     }
@@ -2204,7 +2204,7 @@ function GuildSystem:ProcessBossRaidEvent(eventId)
 end
 
 function GuildSystem:ProcessGuildEvents()
-    local currentTime = tick()
+    local currentTime = time()
     
     for eventId, event in pairs(self.guildEvents) do
         if event.status == "ACTIVE" then
@@ -2546,7 +2546,7 @@ function GuildSystem:GetActiveAnimeGuildBonus(guildId, bonusId)
     local guildBonuses = self.animeGuildBonuses[guildId]
     if guildBonuses and guildBonuses[bonusId] then
         local bonus = guildBonuses[bonusId]
-        if tick() < bonus.expiresAt then
+        if time() < bonus.expiresAt then
             return bonus
         end
     end
@@ -2607,7 +2607,7 @@ function GuildSystem:GetAnimeGuildStats(guildId)
     local guildBonuses = self.animeGuildBonuses[guildId]
     if guildBonuses then
         for bonusId, bonus in pairs(guildBonuses) do
-            if tick() < bonus.expiresAt then
+            if time() < bonus.expiresAt then
                 stats.activeBonuses[bonusId] = bonus
             end
         end
@@ -2677,7 +2677,7 @@ function GuildSystem:GetAnimeGuildMetrics()
     -- Count active anime bonuses
     for guildId, bonuses in pairs(self.animeGuildBonuses) do
         for _, bonus in pairs(bonuses) do
-            if tick() < bonus.expiresAt then
+            if time() < bonus.expiresAt then
                 metrics.activeAnimeBonuses = metrics.activeAnimeBonuses + 1
             end
         end

--- a/src/Competitive/SecurityManager.lua
+++ b/src/Competitive/SecurityManager.lua
@@ -375,7 +375,7 @@ end
 function SecurityManager:SetupPeriodicChecks()
     -- Run security checks every 5 seconds
     RunService.Heartbeat:Connect(function()
-        local currentTime = tick()
+        local currentTime = time()
         if currentTime % 5 < 0.1 then -- Every 5 seconds
             self:RunSecurityChecks()
         end
@@ -419,7 +419,7 @@ function SecurityManager:CheckRateLimit(player, action)
     if not rateLimiter then return true end
     
     local playerData = rateLimiter.players[player.UserId]
-    local currentTime = tick()
+    local currentTime = time()
     
     if not playerData then
         playerData = { calls = {}, lastReset = currentTime }
@@ -734,11 +734,11 @@ function SecurityManager:TrackPlayerPosition(player)
     local playerData = self.positionTracker[player.UserId]
     
     if not playerData then
-        playerData = { positions = {}, lastUpdate = tick() }
+        playerData = { positions = {}, lastUpdate = time() }
         self.positionTracker[player.UserId] = playerData
     end
     
-    local currentTime = tick()
+    local currentTime = time()
     local timeSinceLastUpdate = currentTime - playerData.lastUpdate
     
     if timeSinceLastUpdate > 0.1 then -- Update every 100ms
@@ -797,7 +797,7 @@ function SecurityManager:RecordViolation(player, violationType, details)
     
     local violation = {
         type = violationType,
-        timestamp = tick(),
+        timestamp = time(),
         details = details or {}
     }
     
@@ -815,7 +815,7 @@ function SecurityManager:RecordViolation(player, violationType, details)
         self.suspiciousPlayers[player.UserId] = {
             player = player,
             violations = playerData.violations,
-            monitoringStart = tick()
+            monitoringStart = time()
         }
     end
 end
@@ -863,7 +863,7 @@ function SecurityManager:ApplyPermanentBan(player)
     -- Add to blacklist and kick
     self.blacklistedPlayers[player.UserId] = {
         reason = "Multiple security violations",
-        timestamp = tick()
+        timestamp = time()
     }
     player:Kick("You have been permanently banned due to multiple security violations.")
 end
@@ -886,7 +886,7 @@ end
 -- Log security event
 function SecurityManager:LogSecurityEvent(player, eventType, details)
     local logEntry = {
-        timestamp = tick(),
+        timestamp = time(),
         player = player.Name,
         userId = player.UserId,
         eventType = eventType,
@@ -920,7 +920,7 @@ end
 
 -- Clean up old data
 function SecurityManager:CleanupOldData()
-    local currentTime = tick()
+    local currentTime = time()
     
     -- Clean up old position data
     for userId, playerData in pairs(self.positionTracker) do
@@ -1001,7 +1001,7 @@ function SecurityManager:BlacklistPlayer(adminPlayer, targetPlayer, reason)
     self.blacklistedPlayers[targetPlayer.UserId] = {
         reason = reason,
         admin = adminPlayer.Name,
-        timestamp = tick()
+        timestamp = time()
     }
     
     targetPlayer:Kick("You have been blacklisted: " .. reason)
@@ -1087,7 +1087,7 @@ function SecurityManager:GetSecurityStatus()
         rateLimitingEnabled = true,
         inputValidationEnabled = true,
         securityWrapperIntegrated = SecurityWrapper ~= nil,
-        lastUpdate = tick()
+        lastUpdate = time()
     }
 end
 

--- a/src/Competitive/SocialSystem.lua
+++ b/src/Competitive/SocialSystem.lua
@@ -253,7 +253,7 @@ function SocialSystem:InitializePlayerData(player)
             friends = {},
             pendingRequests = {},
             blockedPlayers = {},
-            lastOnline = tick(),
+            lastOnline = time(),
             status = "ONLINE"
         }
     end
@@ -332,7 +332,7 @@ function SocialSystem:SendFriendRequest(sender, receiver)
         senderName = sender.Name,
         receiver = receiverId,
         receiverName = receiver.Name,
-        timestamp = tick(),
+        timestamp = time(),
         status = FRIEND_STATUS.PENDING
     }
     
@@ -342,7 +342,7 @@ function SocialSystem:SendFriendRequest(sender, receiver)
             friends = {},
             pendingRequests = {},
             blockedPlayers = {},
-            lastOnline = tick(),
+            lastOnline = time(),
             status = "OFFLINE"
         }
     end
@@ -399,13 +399,13 @@ function SocialSystem:AcceptFriendRequest(player, requestId)
     table.insert(playerData.friends, {
         userId = request.sender,
         name = request.senderName,
-        addedAt = tick()
+        addedAt = time()
     })
     
     table.insert(senderData.friends, {
         userId = userId,
         name = player.Name,
-        addedAt = tick()
+        addedAt = time()
     })
     
     -- Remove from pending requests
@@ -496,7 +496,7 @@ function SocialSystem:BlockPlayer(player, targetUserId)
     -- Add to blocked list
     table.insert(playerData.blockedPlayers, {
         userId = targetUserId,
-        blockedAt = tick()
+        blockedAt = time()
     })
     
     print("SocialSystem: " .. player.Name .. " blocked player " .. targetUserId)
@@ -534,7 +534,7 @@ function SocialSystem:SendChatMessage(player, channelId, message)
     -- Check chat cooldown
     local userId = player.UserId
     local lastMessageTime = self.lastChatUpdate
-    if tick() - lastMessageTime < self.chatCooldown then
+    if time() - lastMessageTime < self.chatCooldown then
         return false, "Message sent too quickly"
     end
     
@@ -551,7 +551,7 @@ function SocialSystem:SendChatMessage(player, channelId, message)
         senderName = player.Name,
         channel = channelId,
         message = filteredMessage,
-        timestamp = tick()
+        timestamp = time()
     }
     
     -- Add to chat channel
@@ -569,7 +569,7 @@ function SocialSystem:SendChatMessage(player, channelId, message)
         table.remove(self.chatChannels[channelId].messages, 1)
     end
     
-    self.chatChannels[channelId].lastMessage = tick()
+    self.chatChannels[channelId].lastMessage = time()
     
     -- Broadcast to channel
     self:BroadcastChatMessage(channelId, chatMessage)
@@ -606,7 +606,7 @@ function SocialSystem:SendPrivateMessage(sender, receiver, message)
         receiver = receiverId,
         receiverName = receiver.Name,
         message = filteredMessage,
-        timestamp = tick(),
+        timestamp = time(),
         read = false
     }
     
@@ -663,7 +663,7 @@ function SocialSystem:CreateSocialGroup(creator, groupName, groupType, descripti
         creatorName = creator.Name,
         members = {},
         maxMembers = self.maxGroupMembers,
-        createdAt = tick(),
+        createdAt = time(),
         settings = {
             public = true,
             allowInvites = true,
@@ -674,7 +674,7 @@ function SocialSystem:CreateSocialGroup(creator, groupName, groupType, descripti
     -- Add creator as leader
     group.members[userId] = {
         role = "LEADER",
-        joinedAt = tick(),
+        joinedAt = time(),
         permissions = {
             "INVITE_MEMBERS",
             "KICK_MEMBERS",
@@ -723,7 +723,7 @@ function SocialSystem:JoinSocialGroup(player, groupId)
         table.insert(group.pendingMembers, {
             userId = userId,
             name = player.Name,
-            requestedAt = tick()
+            requestedAt = time()
         })
         
         print("SocialSystem: " .. player.Name .. " requested to join group: " .. group.name)
@@ -733,7 +733,7 @@ function SocialSystem:JoinSocialGroup(player, groupId)
     -- Add to group
     group.members[userId] = {
         role = "MEMBER",
-        joinedAt = tick(),
+        joinedAt = time(),
         permissions = {}
     }
     
@@ -809,8 +809,8 @@ function SocialSystem:InviteToSocialGroup(inviter, targetPlayer, groupId)
         inviterName = inviter.Name,
         target = targetId,
         targetName = targetPlayer.Name,
-        timestamp = tick(),
-        expiresAt = tick() + (24 * 60 * 60) -- 24 hours
+        timestamp = time(),
+        expiresAt = time() + (24 * 60 * 60) -- 24 hours
     }
     
     -- Add to group invitations
@@ -852,7 +852,7 @@ function SocialSystem:JoinVoiceChat(player, channelId)
     -- Add participant
     channel.participants[userId] = {
         player = player,
-        joinedAt = tick(),
+        joinedAt = time(),
         muted = false,
         speaking = false
     }
@@ -905,7 +905,7 @@ function SocialSystem:UseEmote(player, emoteId)
         playerName = player.Name,
         emoteId = emoteId,
         emoteName = emote.name,
-        timestamp = tick()
+        timestamp = time()
     }
     
     -- Notify emote usage
@@ -1163,7 +1163,7 @@ function SocialSystem:JoinAnimeFandom(player, animeType)
     -- Add player to fandom
     fandom.members[userId] = {
         playerName = player.Name,
-        joinedAt = tick(),
+        joinedAt = time(),
         role = "MEMBER",
         contributions = {
             discussions = 0,
@@ -1172,7 +1172,7 @@ function SocialSystem:JoinAnimeFandom(player, animeType)
             theories = 0,
             collaborations = 0
         },
-        lastActivity = tick()
+        lastActivity = time()
     }
     
     -- Update fandom stats
@@ -1184,7 +1184,7 @@ function SocialSystem:JoinAnimeFandom(player, animeType)
     end
     table.insert(self.animeFandomMembers[userId], {
         animeType = animeType,
-        joinedAt = tick(),
+        joinedAt = time(),
         role = "MEMBER"
     })
     
@@ -1271,8 +1271,8 @@ function SocialSystem:InviteToAnimeFandom(inviter, targetPlayer, animeType)
         inviterName = inviter.Name,
         target = targetId,
         targetName = targetPlayer.Name,
-        timestamp = tick(),
-        expiresAt = tick() + (24 * 60 * 60) -- 24 hours
+        timestamp = time(),
+        expiresAt = time() + (24 * 60 * 60) -- 24 hours
     }
     
     -- Add to fandom invitations
@@ -1325,7 +1325,7 @@ function SocialSystem:CreateAnimeEvent(creator, animeType, eventType, eventName,
         participants = {},
         maxParticipants = 100,
         status = "UPCOMING",
-        createdAt = tick(),
+        createdAt = time(),
         settings = {
             public = true,
             allowInvites = true,
@@ -1337,7 +1337,7 @@ function SocialSystem:CreateAnimeEvent(creator, animeType, eventType, eventName,
     -- Add creator as participant
     event.participants[userId] = {
         playerName = creator.Name,
-        joinedAt = tick(),
+        joinedAt = time(),
         role = "ORGANIZER"
     }
     
@@ -1391,7 +1391,7 @@ function SocialSystem:JoinAnimeEvent(player, eventId)
     -- Add player to event
     event.participants[userId] = {
         playerName = player.Name,
-        joinedAt = tick(),
+        joinedAt = time(),
         role = "PARTICIPANT"
     }
     
@@ -1403,7 +1403,7 @@ function SocialSystem:JoinAnimeEvent(player, eventId)
         eventId = eventId,
         eventName = event.name,
         animeType = event.animeType,
-        joinedAt = tick()
+        joinedAt = time()
     })
     
     -- Notify event join
@@ -1482,7 +1482,7 @@ function SocialSystem:CreateAnimeDiscussion(player, animeType, title, content, d
         discussionType = discussionType or "GENERAL",
         creator = userId,
         creatorName = player.Name,
-        createdAt = tick(),
+        createdAt = time(),
         replies = {},
         likes = 0,
         views = 0,
@@ -1537,7 +1537,7 @@ function SocialSystem:UnlockAnimeAchievement(player, achievementCategory, achiev
         category = achievementCategory,
         name = achievementName,
         description = description or "",
-        unlockedAt = tick(),
+        unlockedAt = time(),
         playerName = player.Name
     }
     
@@ -1581,7 +1581,7 @@ function SocialSystem:StartAnimeCollaboration(initiator, animeType, collaboratio
         participants = {},
         maxParticipants = maxParticipants or 10,
         status = "ACTIVE",
-        createdAt = tick(),
+        createdAt = time(),
         progress = 0,
         completionDate = nil
     }
@@ -1589,7 +1589,7 @@ function SocialSystem:StartAnimeCollaboration(initiator, animeType, collaboratio
     -- Add initiator as participant
     collaboration.participants[userId] = {
         playerName = initiator.Name,
-        joinedAt = tick(),
+        joinedAt = time(),
         role = "LEADER",
         contributions = 0
     }
@@ -1654,7 +1654,7 @@ function SocialSystem:ShareAnimeFanArt(player, animeType, title, description, ar
         artData = artData or "",
         creator = userId,
         creatorName = player.Name,
-        createdAt = tick(),
+        createdAt = time(),
         likes = 0,
         views = 0,
         comments = {},
@@ -1718,7 +1718,7 @@ function SocialSystem:CreateAnimeTheory(player, animeType, title, content, theor
         evidence = evidence or "",
         creator = userId,
         creatorName = player.Name,
-        createdAt = tick(),
+        createdAt = time(),
         likes = 0,
         views = 0,
         comments = {},
@@ -1841,7 +1841,7 @@ end
 -- Periodic updates
 function SocialSystem:SetupPeriodicUpdates()
     RunService.Heartbeat:Connect(function()
-        local currentTime = tick()
+        local currentTime = time()
         
         -- Update chat channels
         if currentTime - self.lastChatUpdate >= self.chatUpdateInterval then
@@ -1886,7 +1886,7 @@ function SocialSystem:UpdateAnimeSocialSystems()
 end
 
 function SocialSystem:UpdateAnimeEventStatuses()
-    local currentTime = tick()
+    local currentTime = time()
     
     for eventId, event in pairs(self.animeEvents) do
         if event.status == "UPCOMING" and currentTime >= event.startTime then
@@ -1900,7 +1900,7 @@ function SocialSystem:UpdateAnimeEventStatuses()
 end
 
 function SocialSystem:CleanupExpiredAnimeFandomInvitations()
-    local currentTime = tick()
+    local currentTime = time()
     
     for animeType, fandom in pairs(self.animeFandoms) do
         if fandom.invitations then
@@ -1951,7 +1951,7 @@ function SocialSystem:UpdateAnimeSocialMetrics()
 end
 
 function SocialSystem:CleanupInactiveAnimeDiscussions()
-    local currentTime = tick()
+    local currentTime = time()
     local inactiveThreshold = 30 * 24 * 60 * 60 -- 30 days
     
     for animeType, fandom in pairs(self.animeFandoms) do
@@ -1984,7 +1984,7 @@ function SocialSystem:CleanupInactiveAnimeDiscussions()
 end
 
 function SocialSystem:CleanupExpiredInvitations()
-    local currentTime = tick()
+    local currentTime = time()
     
     for groupId, group in pairs(self.socialGroups) do
         if group.invitations then
@@ -2025,7 +2025,7 @@ function SocialSystem:NotifyFriendAdded(player, request)
         self.networkManager:SendToClient(player, RemoteEvents.FriendAdded, {
             friendId = request.sender,
             friendName = request.senderName,
-            timestamp = tick()
+            timestamp = time()
         })
     end
 end
@@ -2035,7 +2035,7 @@ function SocialSystem:NotifyFriendRemoved(player, removedPlayer)
         self.networkManager:SendToClient(player, RemoteEvents.FriendRemoved, {
             friendId = removedPlayer.UserId,
             friendName = removedPlayer.Name,
-            timestamp = tick()
+            timestamp = time()
         })
     end
 end
@@ -2054,7 +2054,7 @@ function SocialSystem:NotifyFriendsOnline(player)
             self.networkManager:SendToClient(friendPlayer, RemoteEvents.FriendOnline, {
                 friendId = userId,
                 friendName = player.Name,
-                timestamp = tick()
+                timestamp = time()
             })
         end
     end
@@ -2074,7 +2074,7 @@ function SocialSystem:NotifyFriendsOffline(player)
             self.networkManager:SendToClient(friendPlayer, RemoteEvents.FriendOffline, {
                 friendId = userId,
                 friendName = player.Name,
-                timestamp = tick()
+                timestamp = time()
             })
         end
     end
@@ -2109,7 +2109,7 @@ function SocialSystem:NotifySocialGroupCreated(creator, group)
             groupId = group.id,
             groupName = group.name,
             groupType = group.type,
-            timestamp = tick()
+            timestamp = time()
         })
     end
 end
@@ -2120,7 +2120,7 @@ function SocialSystem:NotifySocialGroupJoined(player, group)
             groupId = group.id,
             groupName = group.name,
             groupType = group.type,
-            timestamp = tick()
+            timestamp = time()
         })
     end
 end
@@ -2130,7 +2130,7 @@ function SocialSystem:NotifySocialGroupLeft(player, group)
         self.networkManager:SendToClient(player, RemoteEvents.SocialGroupLeft, {
             groupId = group.id,
             groupName = group.name,
-            timestamp = tick()
+            timestamp = time()
         })
     end
 end
@@ -2160,7 +2160,7 @@ function SocialSystem:NotifyVoiceChatUpdate(channelId, action, player)
                 action = action,
                 playerId = player.UserId,
                 playerName = player.Name,
-                timestamp = tick()
+                timestamp = time()
             })
         end
     end
@@ -2186,7 +2186,7 @@ function SocialSystem:NotifyAnimeFandomJoined(player, animeType)
     if player then
         self.networkManager:SendToClient(player, RemoteEvents.AnimeFandomJoined, {
             animeType = animeType,
-            timestamp = tick()
+            timestamp = time()
         })
     end
 end
@@ -2195,7 +2195,7 @@ function SocialSystem:NotifyAnimeFandomLeft(player, animeType)
     if player then
         self.networkManager:SendToClient(player, RemoteEvents.AnimeFandomLeft, {
             animeType = animeType,
-            timestamp = tick()
+            timestamp = time()
         })
     end
 end
@@ -2218,7 +2218,7 @@ function SocialSystem:NotifyAnimeEventJoined(player, event)
             eventName = event.name,
             animeType = event.animeType,
             eventType = event.eventType,
-            timestamp = tick()
+            timestamp = time()
         })
     end
 end
@@ -2229,7 +2229,7 @@ function SocialSystem:NotifyAnimeEventLeft(player, event)
             eventId = event.id,
             eventName = event.name,
             animeType = event.animeType,
-            timestamp = tick()
+            timestamp = time()
         })
     end
 end
@@ -2241,7 +2241,7 @@ function SocialSystem:NotifyAnimeAchievementUnlocked(player, achievement)
             category = achievement.category,
             name = achievement.name,
             description = achievement.description,
-            timestamp = tick()
+            timestamp = time()
         })
     end
 end
@@ -2253,7 +2253,7 @@ function SocialSystem:NotifyAnimeCollaborationStarted(player, collaboration)
             title = collaboration.title,
             animeType = collaboration.animeType,
             collaborationType = collaboration.collaborationType,
-            timestamp = tick()
+            timestamp = time()
         })
     end
 end
@@ -2265,7 +2265,7 @@ function SocialSystem:NotifyAnimeFanArtShared(player, fanArt)
             title = fanArt.title,
             animeType = fanArt.animeType,
             artType = fanArt.artType,
-            timestamp = tick()
+            timestamp = time()
         })
     end
 end
@@ -2277,7 +2277,7 @@ function SocialSystem:NotifyAnimeDiscussionCreated(player, discussion)
             title = discussion.title,
             animeType = discussion.animeType,
             discussionType = discussion.discussionType,
-            timestamp = tick()
+            timestamp = time()
         })
     end
 end
@@ -2298,7 +2298,7 @@ function SocialSystem:GetPlayerFriends(player)
             userId = friend.userId,
             name = friend.name,
             online = friendPlayer ~= nil,
-            lastSeen = friendPlayer and tick() or (playerData.lastOnline or 0)
+            lastSeen = friendPlayer and time() or (playerData.lastOnline or 0)
         })
     end
     

--- a/src/Competitive/TradingSystem.lua
+++ b/src/Competitive/TradingSystem.lua
@@ -341,8 +341,8 @@ function TradingSystem:CreateTrade(player1, player2)
         player1Items = {},
         player2Items = {},
         status = TRADE_STATUS.PENDING,
-        createdAt = tick(),
-        expiresAt = tick() + self.tradeTimeout,
+        createdAt = time(),
+        expiresAt = time() + self.tradeTimeout,
         accepted1 = false,
         accepted2 = false
     }
@@ -514,7 +514,7 @@ function TradingSystem:ExecuteTrade(tradeId)
     if success then
         -- Mark trade as completed
         tradeData.status = TRADE_STATUS.COMPLETED
-        tradeData.completedAt = tick()
+        tradeData.completedAt = time()
         
         -- Update trade history
         self:UpdateTradeHistory(tradeData)
@@ -585,7 +585,7 @@ function TradingSystem:CancelTrade(tradeId, reason)
     end
     
     tradeData.status = TRADE_STATUS.CANCELLED
-    tradeData.cancelledAt = tick()
+    tradeData.cancelledAt = time()
     tradeData.cancelReason = reason
     
     -- Notify cancellation
@@ -623,8 +623,8 @@ function TradingSystem:ListMarketItem(player, itemType, itemId, quantity, price)
         itemId = itemId,
         quantity = quantity,
         price = price,
-        listedAt = tick(),
-        expiresAt = tick() + (7 * 24 * 60 * 60), -- 7 days
+        listedAt = time(),
+        expiresAt = time() + (7 * 24 * 60 * 60), -- 7 days
         status = "ACTIVE"
     }
     
@@ -655,7 +655,7 @@ function TradingSystem:PurchaseMarketItem(buyer, listingId)
         return false, "Listing is no longer active"
     end
     
-    if listing.expiresAt < tick() then
+    if listing.expiresAt < time() then
         listing.status = "EXPIRED"
         return false, "Listing has expired"
     end
@@ -681,7 +681,7 @@ function TradingSystem:PurchaseMarketItem(buyer, listingId)
     
     -- Mark listing as sold
     listing.status = "SOLD"
-    listing.soldAt = tick()
+    listing.soldAt = time()
     listing.buyer = buyer.UserId
     listing.buyerName = buyer.Name
     
@@ -780,8 +780,8 @@ function TradingSystem:CreateAnimeCardTrade(player1, player2, cards1, cards2)
         cards1 = cards1,
         cards2 = cards2,
         status = TRADE_STATUS.PENDING,
-        createdAt = tick(),
-        expiresAt = tick() + self.tradeTimeout,
+        createdAt = time(),
+        expiresAt = time() + self.tradeTimeout,
         accepted1 = false,
         accepted2 = false,
         estimatedValue = self:CalculateAnimeCardTradeValue(cards1, cards2)
@@ -923,8 +923,8 @@ function TradingSystem:CreateArtifactTrade(player1, player2, artifacts1, artifac
         artifacts1 = artifacts1,
         artifacts2 = artifacts2,
         status = TRADE_STATUS.PENDING,
-        createdAt = tick(),
-        expiresAt = tick() + self.tradeTimeout,
+        createdAt = time(),
+        expiresAt = time() + self.tradeTimeout,
         accepted1 = false,
         accepted2 = false,
         estimatedValue = self:CalculateArtifactTradeValue(artifacts1, artifacts2)
@@ -1071,8 +1071,8 @@ function TradingSystem:CreateSeasonalItemTrade(player1, player2, items1, items2)
         items1 = items1,
         items2 = items2,
         status = TRADE_STATUS.PENDING,
-        createdAt = tick(),
-        expiresAt = tick() + self.tradeTimeout,
+        createdAt = time(),
+        expiresAt = time() + self.tradeTimeout,
         accepted1 = false,
         accepted2 = false,
         estimatedValue = self:CalculateSeasonalItemTradeValue(items1, items2)
@@ -1226,8 +1226,8 @@ function TradingSystem:CreateCrossAnimeTrade(player1, player2, items1, items2)
         items1 = items1,
         items2 = items2,
         status = TRADE_STATUS.PENDING,
-        createdAt = tick(),
-        expiresAt = tick() + self.tradeTimeout,
+        createdAt = time(),
+        expiresAt = time() + self.tradeTimeout,
         accepted1 = false,
         accepted2 = false,
         estimatedValue = self:CalculateCrossAnimeTradeValue(items1, items2)
@@ -1382,7 +1382,7 @@ function TradingSystem:CreateEscrow(tradeData)
         id = escrowId,
         tradeId = tradeData.id,
         items = {},
-        createdAt = tick(),
+        createdAt = time(),
         status = "ACTIVE"
     }
     return escrowId
@@ -1446,7 +1446,7 @@ function TradingSystem:CloseEscrow(escrowId)
     local escrow = self.escrowSystem[escrowId]
     if escrow then
         escrow.status = "CLOSED"
-        escrow.closedAt = tick()
+        escrow.closedAt = time()
     end
 end
 
@@ -1481,7 +1481,7 @@ function TradingSystem:UpdateMarketAnalytics(itemType, itemId, price, quantity)
     table.insert(analytics.priceHistory, {
         price = price,
         quantity = math.abs(quantity),
-        timestamp = tick()
+        timestamp = time()
     })
     
     -- Keep only last 100 price points
@@ -1489,13 +1489,13 @@ function TradingSystem:UpdateMarketAnalytics(itemType, itemId, price, quantity)
         table.remove(analytics.priceHistory, 1)
     end
     
-    analytics.lastUpdated = tick()
+    analytics.lastUpdated = time()
 end
 
 -- Periodic updates
 function TradingSystem:SetupPeriodicUpdates()
     RunService.Heartbeat:Connect(function()
-        local currentTime = tick()
+        local currentTime = time()
         
         -- Update market prices
         if currentTime - self.lastMarketUpdate >= self.marketUpdateInterval then
@@ -1518,7 +1518,7 @@ function TradingSystem:UpdateMarketPrices()
 end
 
 function TradingSystem:CleanupExpiredTrades()
-    local currentTime = tick()
+    local currentTime = time()
     local expiredTrades = {}
     
     for tradeId, tradeData in pairs(self.activeTrades) do
@@ -1533,7 +1533,7 @@ function TradingSystem:CleanupExpiredTrades()
 end
 
 function TradingSystem:CleanupExpiredListings()
-    local currentTime = tick()
+    local currentTime = time()
     local expiredListings = {}
     
     for listingId, listing in pairs(self.marketListings) do
@@ -1565,27 +1565,27 @@ function TradingSystem:UpdateTradeHistory(tradeData)
     
     if player1Data then
         player1Data.completedTrades = player1Data.completedTrades + 1
-        player1Data.lastTradeTime = tick()
+        player1Data.lastTradeTime = time()
         player1Data.totalValue = player1Data.totalValue + self:CalculateTradeValue(tradeData.player1Items)
         
         table.insert(player1Data.tradeHistory, {
             tradeId = tradeData.id,
             partner = tradeData.player2Name,
             items = tradeData.player1Items,
-            timestamp = tick()
+            timestamp = time()
         })
     end
     
     if player2Data then
         player2Data.completedTrades = player2Data.completedTrades + 1
-        player2Data.lastTradeTime = tick()
+        player2Data.lastTradeTime = time()
         player2Data.totalValue = player2Data.totalValue + self:CalculateTradeValue(tradeData.player2Items)
         
         table.insert(player2Data.tradeHistory, {
             tradeId = tradeData.id,
             partner = tradeData.player1Name,
             items = tradeData.player2Items,
-            timestamp = tick()
+            timestamp = time()
         })
     end
 end
@@ -1845,7 +1845,7 @@ function TradingSystem:UpdateAnimeCardTradeMetrics(tradeData)
     local tradeValue = tradeData.estimatedValue.player1Value + tradeData.estimatedValue.player2Value
     table.insert(metrics.priceHistory, {
         value = tradeValue,
-        timestamp = tick(),
+        timestamp = time(),
         cardCount = #tradeData.cards1 + #tradeData.cards2
     })
     
@@ -1884,7 +1884,7 @@ function TradingSystem:UpdateArtifactTradeMetrics(tradeData)
     local tradeValue = tradeData.estimatedValue.player1Value + tradeData.estimatedValue.player2Value
     table.insert(metrics.priceHistory, {
         value = tradeValue,
-        timestamp = tick(),
+        timestamp = time(),
         artifactCount = #tradeData.artifacts1 + #tradeData.artifacts2
     })
     
@@ -1923,7 +1923,7 @@ function TradingSystem:UpdateSeasonalItemTradeMetrics(tradeData)
     local tradeValue = tradeData.estimatedValue.player1Value + tradeData.estimatedValue.player2Value
     table.insert(metrics.priceHistory, {
         value = tradeValue,
-        timestamp = tick(),
+        timestamp = time(),
         itemCount = #tradeData.items1 + #tradeData.items2
     })
     
@@ -1964,7 +1964,7 @@ function TradingSystem:UpdateCrossAnimeTradeMetrics(tradeData)
     local tradeValue = tradeData.estimatedValue.player1Value + tradeData.estimatedValue.player2Value
     table.insert(metrics.priceHistory, {
         value = tradeValue,
-        timestamp = tick(),
+        timestamp = time(),
         itemCount = #tradeData.items1 + #tradeData.items2
     })
     
@@ -2341,7 +2341,7 @@ function TradingSystem:GetTradingMetrics()
         metrics.escrowStatus[escrowId] = {
             status = escrow.status,
             value = escrow.totalValue or 0,
-            timeActive = tick() - escrow.createdAt
+            timeActive = time() - escrow.createdAt
         }
     end
     

--- a/src/Hub/AdvancedPlotSystem.lua
+++ b/src/Hub/AdvancedPlotSystem.lua
@@ -100,13 +100,13 @@ function AdvancedPlotSystem:InitializePlotSystem()
             level = 1,
             maxLevel = 10,
             upgradeCost = Constants.ECONOMY.ABILITY_BASE_COST,
-            lastUpgraded = tick()
+            lastUpgraded = time()
         }
         
         self.plotThemes[plotId] = {
             current = Constants.PLOT_THEMES[plotId] or "Default",
             available = {Constants.PLOT_THEMES[plotId] or "Default"},
-            lastChanged = tick()
+            lastChanged = time()
         }
         
         self.plotDecorations[plotId] = {}
@@ -114,14 +114,14 @@ function AdvancedPlotSystem:InitializePlotSystem()
             level = 1,
             experience = 0,
             experienceRequired = 1000,
-            lastUpdated = tick()
+            lastUpdated = time()
         }
         
         self.plotCustomization[plotId] = {
             buildings = {},
             layout = "default",
             colorScheme = "default",
-            lastModified = tick()
+            lastModified = time()
         }
     end
     
@@ -153,7 +153,7 @@ function AdvancedPlotSystem:UpgradePlot(plotId, upgradeType)
     
     -- Perform upgrade
     upgradeData.level = upgradeData.level + 1
-    upgradeData.lastUpgraded = tick()
+    upgradeData.lastUpgraded = time()
     upgradeData.upgradeCost = self:CalculateNextUpgradeCost(plotId)
     
     -- Update plot prestige
@@ -233,7 +233,7 @@ function AdvancedPlotSystem:ChangePlotTheme(plotId, newTheme)
     -- Change theme
     local oldTheme = themeData.current
     themeData.current = newTheme
-    themeData.lastChanged = tick()
+    themeData.lastChanged = time()
     
     -- Apply theme-specific bonuses
     self:ApplyThemeBonuses(plotId, newTheme)
@@ -302,8 +302,8 @@ function AdvancedPlotSystem:AddPlotDecoration(plotId, decorationId, decorationDa
     decorations[decorationId] = {
         id = decorationId,
         data = decorationData,
-        addedAt = tick(),
-        lastModified = tick()
+        addedAt = time(),
+        lastModified = time()
     }
     
     self.plotDecorations[plotId] = decorations
@@ -366,7 +366,7 @@ function AdvancedPlotSystem:UpdatePlotPrestige(plotId, actionType)
         print("AdvancedPlotSystem: Plot " .. plotId .. " reached prestige level " .. prestigeData.level .. "!")
     end
     
-    prestigeData.lastUpdated = tick()
+    prestigeData.lastUpdated = time()
     
     -- Sync to client
     self:BroadcastPlotPrestigeUpdate(plotId, prestigeData)
@@ -492,7 +492,7 @@ function AdvancedPlotSystem:UpdatePlotSwitchHistory(player, plotId)
     
     table.insert(self.plotSwitchHistory[userId], {
         plotId = plotId,
-        timestamp = tick(),
+        timestamp = time(),
         action = "switch_to"
     })
     
@@ -509,7 +509,7 @@ function AdvancedPlotSystem:BroadcastPlotDecorationUpdate(plotId, decorationId, 
         plotId = plotId,
         decorationId = decorationId,
         decorationData = decorationData,
-        timestamp = tick()
+        timestamp = time()
     }
     
     -- Send to all clients
@@ -522,7 +522,7 @@ function AdvancedPlotSystem:BroadcastPlotPrestigeUpdate(plotId, prestigeData)
     local data = {
         plotId = plotId,
         prestigeData = prestigeData,
-        timestamp = tick()
+        timestamp = time()
     }
     
     -- Send to all clients

--- a/src/Hub/HubManager.lua
+++ b/src/Hub/HubManager.lua
@@ -827,7 +827,7 @@ function HubManager:SwitchPlayerToPlot(player, plotId)
     
     -- Check cooldown (5 seconds between switches)
     local lastSwitch = self.playerPlotSwitchCooldowns and self.playerPlotSwitchCooldowns[player.UserId] or 0
-    local currentTime = tick()
+    local currentTime = time()
     
     if currentTime - lastSwitch < 5 then
         print("HubManager: Error - Plot switching cooldown active for player " .. player.Name)
@@ -1287,7 +1287,7 @@ function HubManager:SaveHubData()
         plots = {},
         playerPlots = {},
         plotThemeAssignments = self.plotThemeAssignments,
-        timestamp = tick()
+        timestamp = time()
     }
     
     -- Save plot data with anime theme info

--- a/src/Hub/HubUI.lua
+++ b/src/Hub/HubUI.lua
@@ -595,7 +595,7 @@ function HubUI:ShowNotification(message, duration, notificationType)
     
     -- Create notification frame
     local notificationFrame = Instance.new("Frame")
-    notificationFrame.Name = "Notification_" .. tick()
+    notificationFrame.Name = "Notification_" .. time()
     notificationFrame.Size = UI_CONFIG.NOTIFICATION_SIZE
     notificationFrame.Position = UDim2.new(0.5, -UI_CONFIG.NOTIFICATION_SIZE.X.Offset / 2, 0, -UI_CONFIG.NOTIFICATION_SIZE.Y.Offset)
     notificationFrame.BackgroundColor3 = self:GetNotificationColor(notificationType)

--- a/src/Multiplayer/CrossTycoonProgression.lua
+++ b/src/Multiplayer/CrossTycoonProgression.lua
@@ -118,7 +118,7 @@ function CrossTycoonProgression:UpdateSharedAbility(player, abilityId, newLevel)
     -- Update ability level
     self.sharedAbilities[userId][abilityId] = {
         level = newLevel,
-        lastUpdated = tick(),
+        lastUpdated = time(),
         tycoonSource = "cross_tycoon"
     }
     
@@ -193,7 +193,7 @@ function CrossTycoonProgression:UpdatePlayerProgression(player)
         abilityCount = abilityCount,
         averageLevel = abilityCount > 0 and (totalLevel / abilityCount) or 0,
         maxLevel = maxLevel,
-        lastUpdated = tick()
+        lastUpdated = time()
     }
     
     print("CrossTycoonProgression: Updated progression for " .. player.Name .. " (Total: " .. totalLevel .. ", Avg: " .. (self.playerProgression[userId].averageLevel) .. ")")
@@ -252,7 +252,7 @@ function CrossTycoonProgression:ProcessCrossTycoonPurchase(player, itemId, baseC
         progressionDiscount = progressionDiscount,
         finalCost = finalCost,
         savings = baseCost - finalCost,
-        lastUpdated = tick()
+        lastUpdated = time()
     }
     
     -- Send economy bonus update to client
@@ -323,7 +323,7 @@ function CrossTycoonProgression:IsPlayerProtectedFromTheft(player)
     if not protection then return false end
     
     -- Check if protection is still active
-    return tick() < protection.expiresAt
+    return time() < protection.expiresAt
 end
 
 function CrossTycoonProgression:ApplyTheftPenalty(player, abilityId, originalLevel)
@@ -337,7 +337,7 @@ function CrossTycoonProgression:ApplyTheftPenalty(player, abilityId, originalLev
     
     -- Set temporary theft protection
     self.theftProtection[userId] = {
-        expiresAt = tick() + 300,  -- 5 minutes of protection
+        expiresAt = time() + 300,  -- 5 minutes of protection
         stolenAbility = abilityId,
         originalLevel = originalLevel
     }
@@ -371,7 +371,7 @@ function CrossTycoonProgression:BroadcastAbilityUpdate(player, abilityId, newLev
         playerName = player.Name,
         abilityId = abilityId,
         newLevel = newLevel,
-        timestamp = tick()
+        timestamp = time()
     }
     
     -- Send to all clients
@@ -388,7 +388,7 @@ function CrossTycoonProgression:BroadcastAbilityTheft(stealer, target, abilityId
         targetName = target.Name,
         abilityId = abilityId,
         stolenLevel = stolenLevel,
-        timestamp = tick()
+        timestamp = time()
     }
     
     -- Send to all clients
@@ -420,7 +420,7 @@ function CrossTycoonProgression:HandlePlayerJoined(player)
         abilityCount = 0,
         averageLevel = 0,
         maxLevel = 0,
-        lastUpdated = tick()
+        lastUpdated = time()
     }
     self.economyBonuses[userId] = nil
     self.theftProtection[userId] = nil

--- a/src/Multiplayer/MultiTycoonManager.lua
+++ b/src/Multiplayer/MultiTycoonManager.lua
@@ -59,7 +59,7 @@ function MultiTycoonManager:SetupPeriodicMaintenance()
     -- Run data integrity checks every 5 minutes
     local integrityCheckConnection
     integrityCheckConnection = RunService.Heartbeat:Connect(function()
-        local currentTime = tick()
+        local currentTime = time()
         if not self.lastIntegrityCheck then
             self.lastIntegrityCheck = 0
         end
@@ -73,7 +73,7 @@ function MultiTycoonManager:SetupPeriodicMaintenance()
     -- Clean up old preserved data every hour
     local cleanupConnection
     cleanupConnection = RunService.Heartbeat:Connect(function()
-        local currentTime = tick()
+        local currentTime = time()
         if not self.lastCleanup then
             self.lastCleanup = 0
         end
@@ -335,7 +335,7 @@ function MultiTycoonManager:SetPlotSwitchCooldown(player)
     if not player then return end
     
     local userId = player.UserId
-    self.plotSwitchingCooldowns[userId] = tick() + Constants.MULTI_TYCOON.PLOT_SWITCHING_COOLDOWN
+    self.plotSwitchingCooldowns[userId] = time() + Constants.MULTI_TYCOON.PLOT_SWITCHING_COOLDOWN
     
     print("MultiTycoonManager: Set plot switch cooldown for " .. player.Name .. " until " .. self.plotSwitchingCooldowns[userId])
 end
@@ -348,7 +348,7 @@ function MultiTycoonManager:CanPlayerSwitchPlots(player)
     
     if not cooldownTime then return true end
     
-    return tick() >= cooldownTime
+    return time() >= cooldownTime
 end
 
 function MultiTycoonManager:GetPlotSwitchCooldownRemaining(player)
@@ -359,7 +359,7 @@ function MultiTycoonManager:GetPlotSwitchCooldownRemaining(player)
     
     if not cooldownTime then return 0 end
     
-    local remaining = cooldownTime - tick()
+    local remaining = cooldownTime - time()
     return math.max(0, remaining)
 end
 
@@ -452,7 +452,7 @@ function MultiTycoonManager:PreserveTycoonData(player, tycoonId)
     
     -- Preserve essential tycoon state
     local preservedData = {
-        lastActiveTime = tick(),
+        lastActiveTime = time(),
         playerId = userId,
         playerName = player.Name,
         -- These will be populated by other systems when they're available
@@ -493,7 +493,7 @@ function MultiTycoonManager:UpdatePreservedData(tycoonId, dataType, data)
     end
     
     self.tycoonData[tycoonId][dataType] = data
-    self.tycoonData[tycoonId].lastUpdateTime = tick()
+    self.tycoonData[tycoonId].lastUpdateTime = time()
     
     print("MultiTycoonManager: Updated preserved data for tycoon " .. tycoonId .. " - " .. dataType)
 end
@@ -536,7 +536,7 @@ end
 
 -- NEW: Clean up old preserved data
 function MultiTycoonManager:CleanupOldPreservedData()
-    local currentTime = tick()
+    local currentTime = time()
     local maxPreservationTime = Constants.MULTI_TYCOON.MAX_PRESERVATION_TIME or (7 * 24 * 60 * 60) -- 7 days default
     
     local cleanedCount = 0
@@ -634,13 +634,13 @@ end
 
 -- NEW: Performance monitoring
 function MultiTycoonManager:StartPerformanceTimer()
-    return tick()
+    return time()
 end
 
 function MultiTycoonManager:EndPerformanceTimer(startTime, operationName)
     if not startTime then return end
     
-    local duration = tick() - startTime
+    local duration = time() - startTime
     if duration > 0.1 then -- Log slow operations
         warn("MultiTycoonManager: " .. (operationName or "Operation") .. " took " .. string.format("%.3f", duration) .. " seconds")
     end
@@ -679,7 +679,7 @@ function MultiTycoonManager:ValidateDataIntegrity()
     end
     
     -- Check for expired cooldowns
-    local currentTime = tick()
+    local currentTime = time()
     for userId, cooldownTime in pairs(self.plotSwitchingCooldowns) do
         if currentTime > cooldownTime then
             -- Clean up expired cooldown

--- a/src/Multiplayer/NetworkManager.lua
+++ b/src/Multiplayer/NetworkManager.lua
@@ -1292,7 +1292,7 @@ function NetworkManager:GetAnimeNetworkingStatus()
         totalAnimeEvents = 0,
         activeAnimeConnections = 0,
         animeEventQueue = 0,
-        lastAnimeSync = tick()
+        lastAnimeSync = time()
     }
     
     -- Count anime-specific remote events
@@ -1367,7 +1367,7 @@ spawn(function()
         local animeStatus = NetworkManager:GetAnimeNetworkingStatus()
         if animeStatus.totalAnimeEvents > 0 then
             print("NetworkManager: Anime system networking status - Events:", animeStatus.totalAnimeEvents, 
-                  "Last sync:", math.floor(tick() - animeStatus.lastAnimeSync), "s ago")
+                  "Last sync:", math.floor(time() - animeStatus.lastAnimeSync), "s ago")
         end
     end
 end)

--- a/src/Multiplayer/PlayerSync.lua
+++ b/src/Multiplayer/PlayerSync.lua
@@ -77,7 +77,7 @@ function PlayerSync:OnPlayerJoin(player)
             MaxHealth = 100,
             Abilities = {},
             CurrentTycoon = nil,
-            LastUpdate = tick()
+            LastUpdate = time()
         }
     end
     
@@ -171,7 +171,7 @@ end
 function PlayerSync:QueueSync(userId, dataType)
     if not lastSyncTime[userId] then return end
     
-    local currentTime = tick()
+    local currentTime = time()
     if currentTime - lastSyncTime[userId] >= SYNC_INTERVAL then
         self:SyncPlayerData(userId)
         lastSyncTime[userId] = currentTime
@@ -186,7 +186,7 @@ function PlayerSync:SyncPlayerData(userId)
     if not player then return end
     
     -- Update last update time
-    playerData[userId].LastUpdate = tick()
+    playerData[userId].LastUpdate = time()
     
     -- Send to all clients
     NetworkManager:FireAllClients("PlayerDataUpdate", userId, playerData[userId])
@@ -226,7 +226,7 @@ end
 -- Start the sync loop
 function PlayerSync:StartSyncLoop()
     RunService.Heartbeat:Connect(function()
-        local currentTime = tick()
+        local currentTime = time()
         
         -- Sync all players periodically
         for userId, lastSync in pairs(lastSyncTime) do
@@ -242,7 +242,7 @@ end
 function PlayerSync:ForceSync(userId)
     if playerData[userId] then
         self:SyncPlayerData(userId)
-        lastSyncTime[userId] = tick()
+        lastSyncTime[userId] = time()
     end
 end
 

--- a/src/Multiplayer/TycoonSync.lua
+++ b/src/Multiplayer/TycoonSync.lua
@@ -51,12 +51,12 @@ function TycoonSync:SetupTycoonData()
             CashGenerated = 0,
             Level = 1,
             Upgrades = {},
-            LastActive = tick(),
+            LastActive = time(),
             IsActive = false,
             Position = Vector3.new(i * 100, 0, 0), -- Spread out tycoons
             WallHealth = {},
             CashGeneratorLevel = 1,
-            LastCashGeneration = tick()
+            LastCashGeneration = time()
         }
         
         lastSyncTime[tycoonId] = 0
@@ -128,7 +128,7 @@ function TycoonSync:ClaimTycoon(userId, tycoonId)
     -- Set ownership
     tycoonOwners[tycoonId] = userId
     tycoonData[tycoonId].Owner = userId
-    tycoonData[tycoonId].LastActive = tick()
+    tycoonData[tycoonId].LastActive = time()
     tycoonData[tycoonId].IsActive = true
     
     -- Notify all clients
@@ -151,7 +151,7 @@ function TycoonSync:SwitchToTycoon(userId, tycoonId)
     if currentOwner ~= userId then return false end
     
     -- Update last active time
-    tycoonData[tycoonId].LastActive = tick()
+    tycoonData[tycoonId].LastActive = time()
     
     -- Notify all clients
     NetworkManager:FireAllClients("TycoonDataUpdate", tycoonId, tycoonData[tycoonId])
@@ -199,7 +199,7 @@ function TycoonSync:UpdateTycoonCash(tycoonId, amount)
     if not tycoonData[tycoonId] then return false end
     
     tycoonData[tycoonId].CashGenerated = tycoonData[tycoonId].CashGenerated + amount
-    tycoonData[tycoonId].LastCashGeneration = tick()
+    tycoonData[tycoonId].LastCashGeneration = time()
     
     -- Queue cash sync
     self:QueueCashSync(tycoonId)
@@ -251,7 +251,7 @@ end
 function TycoonSync:QueueSync(tycoonId, dataType)
     if not lastSyncTime[tycoonId] then return end
     
-    local currentTime = tick()
+    local currentTime = time()
     if currentTime - lastSyncTime[tycoonId] >= TYCOON_SYNC_INTERVAL then
         self:SyncTycoonData(tycoonId)
         lastSyncTime[tycoonId] = currentTime
@@ -262,7 +262,7 @@ end
 function TycoonSync:QueueCashSync(tycoonId)
     if not lastSyncTime[tycoonId] then return end
     
-    local currentTime = tick()
+    local currentTime = time()
     if currentTime - lastSyncTime[tycoonId] >= CASH_SYNC_INTERVAL then
         self:SyncTycoonData(tycoonId)
         lastSyncTime[tycoonId] = currentTime
@@ -274,7 +274,7 @@ function TycoonSync:SyncTycoonData(tycoonId)
     if not tycoonData[tycoonId] then return end
     
     -- Update last sync time
-    lastSyncTime[tycoonId] = tick()
+    lastSyncTime[tycoonId] = time()
     
     -- Send to all clients
     NetworkManager:FireAllClients("TycoonDataUpdate", tycoonId, tycoonData[tycoonId])
@@ -284,7 +284,7 @@ end
 function TycoonSync:StartSyncLoops()
     -- Main tycoon sync loop
     RunService.Heartbeat:Connect(function()
-        local currentTime = tick()
+        local currentTime = time()
         
         for tycoonId, lastSync in pairs(lastSyncTime) do
             if currentTime - lastSync >= TYCOON_SYNC_INTERVAL then
@@ -295,7 +295,7 @@ function TycoonSync:StartSyncLoops()
     
     -- Cash generation loop
     RunService.Heartbeat:Connect(function()
-        local currentTime = tick()
+        local currentTime = time()
         
         for tycoonId, data in pairs(tycoonData) do
             if data.Owner and data.IsActive then
@@ -355,7 +355,7 @@ end
 function TycoonSync:ForceSync(tycoonId)
     if tycoonData[tycoonId] then
         self:SyncTycoonData(tycoonId)
-        lastSyncTime[tycoonId] = tick()
+        lastSyncTime[tycoonId] = time()
     end
 end
 

--- a/src/Player/PlayerAbilities.lua
+++ b/src/Player/PlayerAbilities.lua
@@ -336,7 +336,7 @@ function PlayerAbilities:CreateCashMultiplierEffect(level)
     
     -- More efficient proximity checking
     local function checkTycoonProximity()
-        local currentTime = tick()
+        local currentTime = time()
         if currentTime - lastCheck < 1 then return end -- Check every second
         lastCheck = currentTime
         
@@ -411,7 +411,7 @@ function PlayerAbilities:CreateWallRepairEffect(level)
     local lastRepairTime = 0
     
     local function repairNearbyWalls()
-        local currentTime = tick()
+        local currentTime = time()
         if currentTime - lastRepairTime < repairInterval then return end
         
         if not self.humanoidRootPart then return end
@@ -470,7 +470,7 @@ function PlayerAbilities:CreateTeleportEffect(level)
         if gameProcessed then return end
         
         if input.KeyCode == Enum.KeyCode.T then
-            local currentTime = tick()
+            local currentTime = time()
             if currentTime - lastTeleportTime >= teleportCooldown then
                 if self.humanoidRootPart then
                     -- Teleport to spawn or safe location

--- a/src/Player/PlayerData.lua
+++ b/src/Player/PlayerData.lua
@@ -13,13 +13,13 @@ local DefaultPlayerData = {
     OwnedTycoons = {},  -- Array of tycoon IDs the player owns
     CurrentTycoon = nil,  -- Current active tycoon ID
     Abilities = {},  -- Shared abilities across all tycoons
-    LastSave = tick(),
+    LastSave = time(),
     Level = 1,
     Experience = 0,
     -- NEW: Cross-tycoon progression data
     TotalCashGenerated = 0,  -- Total cash generated across all tycoons
     TycoonStats = {},  -- Individual stats for each owned tycoon
-    LastTycoonSwitch = tick(),
+    LastTycoonSwitch = time(),
     PlotSwitchingCooldown = 5  -- 5 second cooldown between plot switches
 }
 
@@ -156,7 +156,7 @@ function PlayerData:AddTycoonOwnership(tycoonId)
             self.data.TycoonStats[tostring(tycoonId)] = {
                 CashGenerated = 0,
                 UpgradesPurchased = 0,
-                LastActive = tick(),
+                LastActive = time(),
                 Theme = "Unknown"
             }
             
@@ -224,7 +224,7 @@ end
 function PlayerData:SetCurrentTycoon(tycoonId)
     if tycoonId == nil or type(tycoonId) == "string" or type(tycoonId) == "number" then
         -- NEW: Check cooldown for tycoon switching
-        local currentTime = tick()
+        local currentTime = time()
         local timeSinceLastSwitch = currentTime - (self.data.LastTycoonSwitch or 0)
         
         if timeSinceLastSwitch < self.data.PlotSwitchingCooldown then
@@ -269,7 +269,7 @@ function PlayerData:UpdateTycoonStats(tycoonId, stats)
         self.data.TycoonStats[tostring(tycoonId)] = {
             CashGenerated = 0,
             UpgradesPurchased = 0,
-            LastActive = tick(),
+            LastActive = time(),
             Theme = "Unknown"
         }
     end
@@ -300,7 +300,7 @@ end
 
 -- NEW: Get switching cooldown remaining
 function PlayerData:GetSwitchingCooldownRemaining()
-    local currentTime = tick()
+    local currentTime = time()
     local timeSinceLastSwitch = currentTime - (self.data.LastTycoonSwitch or 0)
     local remaining = math.max(0, self.data.PlotSwitchingCooldown - timeSinceLastSwitch)
     return remaining

--- a/src/Server/MainServer.lua
+++ b/src/Server/MainServer.lua
@@ -40,7 +40,7 @@ local MainServer = {}
 -- NEW: Enhanced game state with performance monitoring and deployment features (Step 15)
 local gameState = {
     isInitialized = false,
-    startTime = tick(),
+    startTime = time(),
     deploymentPhase = "DEVELOPMENT", -- DEVELOPMENT, TESTING, PRODUCTION
     -- Milestone 1 systems
     hubManager = nil,
@@ -60,7 +60,7 @@ local gameState = {
     -- NEW: Step 15: Performance & Deployment systems
     performanceOptimizer = nil,
     saveInterval = Constants.SAVE.AUTO_SAVE_INTERVAL,
-    lastSave = tick(),
+    lastSave = time(),
     -- NEW: Enhanced performance monitoring (Step 15)
     performanceMetrics = {
         lastUpdate = 0,
@@ -99,7 +99,7 @@ function MainServer:SafeCall(func, errorContext, ...)
     local success, result = pcall(func, ...)
     if not success then
         local errorInfo = {
-            timestamp = tick(),
+            timestamp = time(),
             context = errorContext or "Unknown",
             error = result,
             traceback = debug.traceback(),
@@ -158,7 +158,7 @@ end
 
 -- NEW: Enhanced performance monitoring method (Step 15)
 function MainServer:UpdatePerformanceMetrics()
-    local currentTime = tick()
+    local currentTime = time()
     local timeSinceLastUpdate = currentTime - gameState.performanceMetrics.lastUpdate
     
     if timeSinceLastUpdate >= gameState.performanceMetrics.updateInterval then
@@ -221,7 +221,7 @@ function MainServer:Initialize()
     print("STEP 15: Final Integration & Deployment...")
     
     -- NEW: Performance monitoring start (Roblox best practice)
-    gameState.performanceMetrics.lastUpdate = tick()
+    gameState.performanceMetrics.lastUpdate = time()
     
     -- Initialize save system FIRST (Required for HubManager)
     self:SafeCall(function()
@@ -317,7 +317,7 @@ function MainServer:SetupPerformanceMonitoring()
                     gameState.performanceOptimizer:CheckAndOptimize()
                 end, "Performance Optimization")
                 
-                gameState.performanceMetrics.lastOptimization = tick()
+                gameState.performanceMetrics.lastOptimization = time()
                 gameState.performanceMetrics.optimizationCount = gameState.performanceMetrics.optimizationCount + 1
             end
         end
@@ -330,7 +330,7 @@ end
 function MainServer:SetupDeploymentMonitoring()
     -- Monitor deployment status every 30 seconds
     connections.deploymentMonitoring = RunService.Heartbeat:Connect(function()
-        local currentTime = tick()
+        local currentTime = time()
         if currentTime - gameState.startTime > 30 then -- Wait 30 seconds after startup
             local readiness = self:CheckDeploymentReadiness()
             if readiness.readyForProduction and gameState.deploymentPhase ~= "PRODUCTION" then
@@ -502,8 +502,8 @@ end
 -- NEW: Enhanced public API for system monitoring and metrics (Step 15)
 function MainServer:GetSystemMetrics()
     local metrics = {
-        timestamp = tick(),
-        serverUptime = tick() - gameState.startTime,
+        timestamp = time(),
+        serverUptime = time() - gameState.startTime,
         activePlayers = #game.Players:GetPlayers(),
         deploymentPhase = gameState.deploymentPhase,
         systems = {},
@@ -691,8 +691,8 @@ function MainServer:GetDeploymentStatus()
         isReady = readiness.readyForProduction,
         phase = gameState.deploymentPhase,
         status = readiness,
-        timestamp = tick(),
-        serverUptime = tick() - gameState.startTime,
+        timestamp = time(),
+        serverUptime = time() - gameState.startTime,
         recommendations = self:GetDeploymentRecommendations()
     }
 end
@@ -1083,7 +1083,7 @@ function MainServer:GetGameState()
         performance = {
             systemHealth = gameState.performanceMetrics.systemHealth,
             activeConnections = gameState.performanceMetrics.activeConnections,
-            serverUptime = tick() - gameState.startTime,
+            serverUptime = time() - gameState.startTime,
             optimizationLevel = gameState.performanceMetrics.optimizationLevel,
             lastOptimization = gameState.performanceMetrics.lastOptimization,
             totalOptimizations = gameState.performanceMetrics.optimizationCount
@@ -1102,8 +1102,8 @@ end
 -- NEW: Get comprehensive system status for deployment (Step 15)
 function MainServer:GetDeploymentReport()
     local report = {
-        timestamp = tick(),
-        serverUptime = tick() - gameState.startTime,
+        timestamp = time(),
+        serverUptime = time() - gameState.startTime,
         deploymentPhase = gameState.deploymentPhase,
         systems = {},
         performance = {},
@@ -1173,12 +1173,12 @@ function MainServer:EmergencyShutdown(reason)
     -- Reset all state
     gameState = {
         isInitialized = false,
-        startTime = tick(),
+        startTime = time(),
         deploymentPhase = "EMERGENCY_SHUTDOWN",
         errorTracker = {
             totalErrors = gameState.errorTracker.totalErrors + 1,
             criticalErrors = gameState.errorTracker.criticalErrors + 1,
-            lastError = { timestamp = tick(), error = reason, emergency = true },
+            lastError = { timestamp = time(), error = reason, emergency = true },
             errorHistory = {},
             recoveryAttempts = 0
         }

--- a/src/Tycoon/AnimeTycoonBuilder.lua
+++ b/src/Tycoon/AnimeTycoonBuilder.lua
@@ -161,7 +161,7 @@ function AnimeTycoonBuilder.new(plotData, player)
     
     -- Performance optimization
     self.updateQueue = {}
-    self.lastUpdate = tick()
+    self.lastUpdate = time()
     self.updateInterval = 0.1 -- 10 updates per second
     self.batchSize = 10
     
@@ -258,7 +258,7 @@ function AnimeTycoonBuilder:CreateBuilding(buildingType, position, level)
         cost = cost,
         power = self:CalculateBuildingPower(buildingType, level),
         earnings = self:CalculateBuildingEarnings(buildingType, level),
-        lastUpdate = tick(),
+        lastUpdate = time(),
         isActive = true,
         animeTheme = self.animeTheme,
         animeSpecific = config.animeSpecific,
@@ -301,7 +301,7 @@ end
 
 -- Generate unique building ID
 function AnimeTycoonBuilder:GenerateBuildingId(buildingType)
-    local timestamp = math.floor(tick() * 1000)
+    local timestamp = math.floor(time() * 1000)
     local random = math.random(1000, 9999)
     return buildingType .. "_" .. self.player.UserId .. "_" .. timestamp .. "_" .. random
 end
@@ -804,7 +804,7 @@ end
 
 -- Update building system (called regularly)
 function AnimeTycoonBuilder:Update()
-    local currentTime = tick()
+    local currentTime = time()
     
     -- Check if it's time to update
     if currentTime - self.lastUpdate < self.updateInterval then
@@ -841,7 +841,7 @@ function AnimeTycoonBuilder:UpdateBuilding(buildingId)
     local building = self.buildings[buildingId]
     if not building or not building.isActive then return end
     
-    local currentTime = tick()
+    local currentTime = time()
     local timeSinceLastUpdate = currentTime - building.lastUpdate
     
     -- Update based on building type

--- a/src/Tycoon/CashGenerator.lua
+++ b/src/Tycoon/CashGenerator.lua
@@ -16,7 +16,7 @@ function CashGenerator.new(tycoonId, owner)
     self.isActive = false
     self.generationRate = Constants.TYCOON.CASH_GENERATION_BASE
     self.generationInterval = Constants.TYCOON.CASH_GENERATION_INTERVAL
-    self.lastGeneration = tick()
+    self.lastGeneration = time()
     self.totalGenerated = 0
     self.upgrades = {
         Rate = 1,
@@ -34,7 +34,7 @@ function CashGenerator:Start()
     if self.isActive then return end
     
     self.isActive = true
-    self.lastGeneration = tick()
+    self.lastGeneration = time()
     
     -- Connect to RunService for continuous generation
     self.connection = RunService.Heartbeat:Connect(function()
@@ -58,7 +58,7 @@ end
 function CashGenerator:Update()
     if not self.isActive then return end
     
-    local currentTime = tick()
+    local currentTime = time()
     local timeSinceLastGeneration = currentTime - self.lastGeneration
     
     if timeSinceLastGeneration >= self.generationInterval then

--- a/src/Tycoon/CharacterSpawner.lua
+++ b/src/Tycoon/CharacterSpawner.lua
@@ -276,14 +276,14 @@ function CharacterSpawner.new(spawnerData, player)
     self.isActive = true
     self.currentLevel = spawnerData.level or 1
     self.spawnInterval = self:CalculateSpawnInterval()
-    self.lastSpawnTime = tick()
+    self.lastSpawnTime = time()
     self.spawnedCharacters = {}
     self.spawnCount = 0
     
     -- Performance optimization
     self.spawnQueue = {}
     self.despawnQueue = {}
-    self.lastUpdate = tick()
+    self.lastUpdate = time()
     self.updateInterval = 0.1 -- 10 updates per second
     
     -- Memory management
@@ -403,7 +403,7 @@ end
 function CharacterSpawner:CanSpawn()
     if not self.isActive then return false end
     
-    local currentTime = tick()
+    local currentTime = time()
     local timeSinceLastSpawn = currentTime - self.lastSpawnTime
     
     -- Check spawn interval
@@ -435,7 +435,7 @@ function CharacterSpawner:SpawnCharacter()
     local characterData = {
         instance = characterInstance,
         data = character,
-        spawnTime = tick(),
+        spawnTime = time(),
         rarity = character.rarity,
         power = character.power,
         abilities = character.abilities
@@ -445,7 +445,7 @@ function CharacterSpawner:SpawnCharacter()
     self.spawnCount = self.spawnCount + 1
     
     -- Update spawn time
-    self.lastSpawnTime = tick()
+    self.lastSpawnTime = time()
     
     -- Add to spawn queue for processing
     table.insert(self.spawnQueue, characterData)
@@ -579,7 +579,7 @@ end
 
 -- Update spawner system
 function CharacterSpawner:Update()
-    local currentTime = tick()
+    local currentTime = time()
     
     -- Check if it's time to update
     if currentTime - self.lastUpdate < self.updateInterval then
@@ -687,7 +687,7 @@ end
 
 -- Clean up expired characters
 function CharacterSpawner:CleanupExpiredCharacters()
-    local currentTime = tick()
+    local currentTime = time()
     
     for i = #self.spawnedCharacters, 1, -1 do
         local characterData = self.spawnedCharacters[i]

--- a/src/Tycoon/CollectionSystem.lua
+++ b/src/Tycoon/CollectionSystem.lua
@@ -150,7 +150,7 @@ function CollectionSystem:AddCharacterToCollection(characterData, animeTheme)
         power = characterData.power,
         abilities = characterData.abilities,
         unlockLevel = characterData.unlockLevel,
-        obtainedAt = tick(),
+        obtainedAt = time(),
         duplicates = 1,
         isFavorited = false,
         lastUsed = 0
@@ -265,7 +265,7 @@ function CollectionSystem:AwardAnimeCurrency(animeTheme, rarityMultiplier)
         
         self.animeCurrencies[themeKey].amount = self.animeCurrencies[themeKey].amount + awardedAmount
         self.animeCurrencies[themeKey].earned = self.animeCurrencies[themeKey].earned + awardedAmount
-        self.animeCurrencies[themeKey].lastEarned = tick()
+        self.animeCurrencies[themeKey].lastEarned = time()
         
         print("CollectionSystem: Awarded " .. awardedAmount .. " " .. currencyData.name .. " for " .. animeTheme)
     end
@@ -302,7 +302,7 @@ function CollectionSystem:ConvertAnimeCurrency(fromTheme, toTheme, amount)
         fromAmount = amount,
         toAmount = convertedAmount,
         conversionRate = conversionRate,
-        timestamp = tick()
+        timestamp = time()
     })
     
     print("CollectionSystem: Converted " .. amount .. " " .. ANIME_CURRENCIES[fromKey].name .. 
@@ -331,7 +331,7 @@ function CollectionSystem:CreateTournament(tournamentType, participants, animeTh
         currentRound = 1,
         brackets = {},
         winner = nil,
-        startTime = tick(),
+        startTime = time(),
         endTime = nil
     }
     

--- a/src/Tycoon/PowerUpSystem.lua
+++ b/src/Tycoon/PowerUpSystem.lua
@@ -222,7 +222,7 @@ function PowerUpSystem.new(powerUpData, player)
     
     -- Performance optimization
     self.cachedCalculations = {}
-    self.lastUpdate = tick()
+    self.lastUpdate = time()
     self.updateInterval = 0.1 -- 10 updates per second
     
     -- Memory management
@@ -319,7 +319,7 @@ function PowerUpSystem:CanUpgrade()
     end
     
     -- Check upgrade cooldown
-    local currentTime = tick()
+    local currentTime = time()
     if currentTime - self.lastUpgradeTime < POWER_UP_CONFIG.upgradeTime then
         return false, "Upgrade cooldown active"
     end
@@ -461,7 +461,7 @@ function PowerUpSystem:StartUpgrade()
     
     -- Add to upgrade queue
     local upgradeData = {
-        startTime = tick(),
+        startTime = time(),
         targetLevel = self.currentLevel + 1,
         cost = self:GetUpgradeCost(),
         requirements = self:GetUpgradeRequirements()
@@ -490,7 +490,7 @@ end
 
 -- Process upgrade queue
 function PowerUpSystem:ProcessUpgradeQueue()
-    local currentTime = tick()
+    local currentTime = time()
     
     for i = #self.upgradeQueue, 1, -1 do
         local upgradeData = self.upgradeQueue[i]
@@ -529,7 +529,7 @@ function PowerUpSystem:CompleteUpgrade(upgradeData)
     
     -- Record upgrade history
     table.insert(self.upgradeHistory, {
-        timestamp = tick(),
+        timestamp = time(),
         oldLevel = oldLevel,
         newLevel = self.currentLevel,
         oldPower = oldPower,
@@ -542,7 +542,7 @@ function PowerUpSystem:CompleteUpgrade(upgradeData)
     })
     
     -- Update last upgrade time
-    self.lastUpgradeTime = tick()
+    self.lastUpgradeTime = time()
     
     -- Check for ability unlocks
     self:CheckAbilityUnlocks()
@@ -672,7 +672,7 @@ end
 
 -- Update power-up system
 function PowerUpSystem:Update()
-    local currentTime = tick()
+    local currentTime = time()
     
     -- Check if it's time to update
     if currentTime - self.lastUpdate < self.updateInterval then

--- a/src/Tycoon/TycoonBase.lua
+++ b/src/Tycoon/TycoonBase.lua
@@ -173,7 +173,7 @@ end
 
 -- Update walls (repair, damage, etc.)
 function TycoonBase:UpdateWalls()
-    local currentTime = tick()
+    local currentTime = time()
     
     for _, wall in ipairs(self.walls) do
         if wall.isDestroyed then

--- a/src/Utils/AdvancedPerformanceBenchmark.lua
+++ b/src/Utils/AdvancedPerformanceBenchmark.lua
@@ -90,14 +90,14 @@ function AdvancedPerformanceBenchmark:initializeBenchmarkSystems()
     
     -- Memory monitoring
     self.memoryConnection = RunService.Heartbeat:Connect(function()
-        if tick() % 5 < 0.1 then
+        if time() % 5 < 0.1 then
             self:updateMemoryMetrics()
         end
     end)
     
     -- Object counting
     self.objectCountConnection = RunService.Heartbeat:Connect(function()
-        if tick() % 10 < 0.1 then
+        if time() % 10 < 0.1 then
             self:updateObjectCounts()
         end
     end)
@@ -148,7 +148,7 @@ function AdvancedPerformanceBenchmark:assessDeviceCapabilities()
     
     -- Frame rate capability test
     local frameRateSamples = {}
-    local startTime = tick()
+    local startTime = time()
     local sampleCount = 0
     local frameRateTest = nil
     
@@ -156,7 +156,7 @@ function AdvancedPerformanceBenchmark:assessDeviceCapabilities()
         sampleCount = sampleCount + 1
         frameRateSamples[sampleCount] = 1 / RunService.Heartbeat:Wait()
         
-        if tick() - startTime >= 5 then -- 5 second test
+        if time() - startTime >= 5 then -- 5 second test
             if frameRateTest then
                 frameRateTest:Disconnect()
             end
@@ -214,7 +214,7 @@ function AdvancedPerformanceBenchmark:startBenchmark(benchmarkName)
     print("=" .. string.rep("=", 60))
     
     isBenchmarking = true
-    benchmarkStartTime = tick()
+    benchmarkStartTime = time()
     currentBenchmark = {
         name = benchmarkName,
         startTime = benchmarkStartTime,
@@ -243,14 +243,14 @@ function AdvancedPerformanceBenchmark:startBenchmarkMonitoring()
     
     -- Memory monitoring
     self.benchmarkMemoryConnection = RunService.Heartbeat:Connect(function()
-        if tick() % 2 < 0.1 then
+        if time() % 2 < 0.1 then
             self:collectMemorySample()
         end
     end)
     
     -- Network monitoring
     self.benchmarkNetworkConnection = RunService.Heartbeat:Connect(function()
-        if tick() % 3 < 0.1 then
+        if time() % 3 < 0.1 then
             self:collectNetworkSample()
         end
     end)
@@ -263,7 +263,7 @@ end
 ]]
 function AdvancedPerformanceBenchmark:collectBenchmarkSample(deltaTime)
     local sample = {
-        timestamp = tick(),
+        timestamp = time(),
         frameRate = 1 / deltaTime,
         updateTime = deltaTime * 1000, -- Convert to milliseconds
         objectCount = self:countGameObjects(),
@@ -276,7 +276,7 @@ function AdvancedPerformanceBenchmark:collectBenchmarkSample(deltaTime)
     table.insert(currentBenchmark.samples, sample)
     
     -- Check if benchmark duration reached
-    if tick() - benchmarkStartTime >= BENCHMARK_CONFIG.BENCHMARK_DURATION then
+    if time() - benchmarkStartTime >= BENCHMARK_CONFIG.BENCHMARK_DURATION then
         self:completeBenchmark()
     end
 end
@@ -286,7 +286,7 @@ end
 ]]
 function AdvancedPerformanceBenchmark:collectMemorySample()
     local memorySample = {
-        timestamp = tick(),
+        timestamp = time(),
         physicalMemory = game:GetService("Stats").PhysicalMemory,
         virtualMemory = game:GetService("Stats").VirtualMemory,
         textureMemory = game:GetService("Stats").TextureMemory,
@@ -301,7 +301,7 @@ end
 ]]
 function AdvancedPerformanceBenchmark:collectNetworkSample()
     local networkSample = {
-        timestamp = tick(),
+        timestamp = time(),
         latency = self:measureNetworkLatency(),
         bandwidth = self:measureNetworkBandwidth()
     }
@@ -331,7 +331,7 @@ function AdvancedPerformanceBenchmark:completeBenchmark()
     
     -- Store benchmark data
     currentBenchmark.results = results
-    currentBenchmark.endTime = tick()
+    currentBenchmark.endTime = time()
     currentBenchmark.duration = currentBenchmark.endTime - currentBenchmark.startTime
     
     table.insert(performanceData.benchmarks, currentBenchmark)
@@ -712,7 +712,7 @@ function AdvancedPerformanceBenchmark:checkPerformanceRegressions()
     
     if regression > BENCHMARK_CONFIG.REGRESSION_THRESHOLD then
         local regressionData = {
-            timestamp = tick(),
+            timestamp = time(),
             severity = "High",
             description = "Performance regression detected",
             details = {
@@ -901,7 +901,7 @@ function AdvancedPerformanceBenchmark:getBenchmarkStatus()
     return {
         isRunning = isBenchmarking,
         currentBenchmark = currentBenchmark,
-        elapsedTime = isBenchmarking and (tick() - benchmarkStartTime) or 0,
+        elapsedTime = isBenchmarking and (time() - benchmarkStartTime) or 0,
         totalDuration = BENCHMARK_CONFIG.BENCHMARK_DURATION
     }
 end

--- a/src/Utils/AutoOptimizationValidator.lua
+++ b/src/Utils/AutoOptimizationValidator.lua
@@ -122,7 +122,7 @@ end
     Update performance metrics during testing
 ]]
 function AutoOptimizationValidator:updatePerformanceMetrics(deltaTime)
-    local currentTime = tick()
+    local currentTime = time()
     
     -- Calculate frame rate
     local frameRate = 1 / deltaTime
@@ -208,7 +208,7 @@ function AutoOptimizationValidator:establishBaseline()
     print("📊 Establishing performance baseline...")
     isRunning = true
     currentTest = "baseline"
-    testStartTime = tick()
+    testStartTime = time()
     
     -- Clear previous samples
     performanceSamples = {}
@@ -216,7 +216,7 @@ function AutoOptimizationValidator:establishBaseline()
     -- Run baseline test
     local baselineConnection
     baselineConnection = RunService.Heartbeat:Connect(function()
-        local elapsed = tick() - testStartTime
+        local elapsed = time() - testStartTime
         
         if elapsed >= VALIDATION_CONFIG.BASELINE_DURATION then
             baselineConnection:Disconnect()
@@ -243,7 +243,7 @@ function AutoOptimizationValidator:completeBaselineTest()
     
     -- Store results
     validationResults.baselines[#validationResults.baselines + 1] = {
-        timestamp = tick(),
+        timestamp = time(),
         metrics = baselineMetrics,
         duration = VALIDATION_CONFIG.BASELINE_DURATION
     }
@@ -394,7 +394,7 @@ function AutoOptimizationValidator:testAutoOptimization()
     print("🚀 Testing auto-optimization features...")
     isRunning = true
     currentTest = "autoOptimization"
-    testStartTime = tick()
+    testStartTime = time()
     
     -- Clear previous samples
     performanceSamples = {}
@@ -405,7 +405,7 @@ function AutoOptimizationValidator:testAutoOptimization()
     -- Run optimization test
     local optimizationConnection
     optimizationConnection = RunService.Heartbeat:Connect(function()
-        local elapsed = tick() - testStartTime
+        local elapsed = time() - testStartTime
         
         if elapsed >= VALIDATION_CONFIG.TEST_DURATION then
             optimizationConnection:Disconnect()
@@ -473,7 +473,7 @@ function AutoOptimizationValidator:completeOptimizationTest()
     
     -- Store results
     validationResults.optimizationTests[#validationResults.optimizationTests + 1] = {
-        timestamp = tick(),
+        timestamp = time(),
         metrics = testMetrics,
         comparison = comparison,
         duration = VALIDATION_CONFIG.TEST_DURATION
@@ -643,7 +643,7 @@ function AutoOptimizationValidator:validateDeviceOptimization()
     
     -- Store results
     validationResults.deviceTests[#validationResults.deviceTests + 1] = {
-        timestamp = tick(),
+        timestamp = time(),
         deviceType = deviceType,
         results = deviceTestResults
     }
@@ -802,7 +802,7 @@ function AutoOptimizationValidator:generateValidationReport()
     print("📊 Generating comprehensive validation report...")
     
     local report = {
-        timestamp = tick(),
+        timestamp = time(),
         summary = {},
         detailedResults = validationResults,
         recommendations = {}

--- a/src/Utils/ConnectionManager.lua
+++ b/src/Utils/ConnectionManager.lua
@@ -48,8 +48,8 @@ function ConnectionManager:CreateConnection(event, callback, groupName, priority
         callback = callback,
         groupName = groupName or "default",
         priority = priority or 1,
-        createdAt = tick(),
-        lastUsed = tick()
+        createdAt = time(),
+        lastUsed = time()
     }
     
     -- Group connections
@@ -69,7 +69,7 @@ end
 function ConnectionManager:CreateThrottledConnection(event, callback, interval, groupName)
     local lastRun = 0
     local wrappedCallback = function(...)
-        local currentTime = tick()
+        local currentTime = time()
         if currentTime - lastRun >= interval then
             lastRun = currentTime
             callback(...)
@@ -196,7 +196,7 @@ end
 
 -- Automatic cleanup of old connections
 function ConnectionManager:AutoCleanup()
-    local currentTime = tick()
+    local currentTime = time()
     if currentTime - performanceMetrics.lastCleanup < performanceMetrics.cleanupInterval then
         return
     end

--- a/src/Utils/DataArchiver.lua
+++ b/src/Utils/DataArchiver.lua
@@ -58,7 +58,7 @@ function DataArchiver:ArchiveData(dataKey, data, maxSize, compressionEnabled)
     end
     
     local archiveData = {
-        timestamp = tick(),
+        timestamp = time(),
         data = {},
         originalSize = #data,
         compressed = false
@@ -207,7 +207,7 @@ function DataArchiver:CleanOldArchives(dataKey)
         return
     end
     
-    local currentTime = tick()
+    local currentTime = time()
     local archivesToRemove = {}
     
     for i, archive in ipairs(archives[dataKey]) do
@@ -228,7 +228,7 @@ end
 
 -- Perform comprehensive cleanup
 function DataArchiver:PerformCleanup()
-    local currentTime = tick()
+    local currentTime = time()
     if currentTime - performanceMetrics.lastCleanup < ARCHIVE_CONFIG.CLEANUP_INTERVAL then
         return
     end
@@ -270,7 +270,7 @@ function DataArchiver:EmergencyCleanup()
     print("DataArchiver: Performing emergency cleanup")
     
     local removedArchives = 0
-    local currentTime = tick()
+    local currentTime = time()
     
     for dataKey, archiveList in pairs(archives) do
         -- Remove archives older than 1 hour

--- a/src/Utils/EnhancedErrorHandler.lua
+++ b/src/Utils/EnhancedErrorHandler.lua
@@ -64,7 +64,7 @@ function EnhancedErrorHandler.new()
     
     -- Performance tracking
     self.errorTimestamps = {}        -- Error frequency tracking
-    self.lastCleanup = tick()        -- Last cleanup time
+    self.lastCleanup = time()        -- Last cleanup time
     
     return self
 end
@@ -174,7 +174,7 @@ end
 -- Set up periodic cleanup
 function EnhancedErrorHandler:SetupPeriodicCleanup()
     RunService.Heartbeat:Connect(function()
-        local currentTime = tick()
+        local currentTime = time()
         if currentTime - self.lastCleanup > 60 then -- Clean up every minute
             self:CleanupOldErrors()
             self.lastCleanup = currentTime
@@ -228,7 +228,7 @@ function EnhancedErrorHandler:CreateErrorInfo(error, context)
         message = tostring(error),
         category = context and context.category or ERROR_CATEGORIES.SYSTEM,
         severity = context and context.severity or ERROR_SEVERITY.ERROR,
-        timestamp = tick(),
+        timestamp = time(),
         stackTrace = debug.traceback(),
         context = context or {},
         player = context and context.player,
@@ -357,7 +357,7 @@ function EnhancedErrorHandler:UpdateErrorCounts(errorInfo)
     self.errorCounts[key] = (self.errorCounts[key] or 0) + 1
     
     -- Track error frequency
-    local currentTime = tick()
+    local currentTime = time()
     if not self.errorTimestamps[key] then
         self.errorTimestamps[key] = {}
     end
@@ -605,7 +605,7 @@ function EnhancedErrorHandler:UpdateSystemHealth()
     end
     
     -- Calculate system health based on error frequency
-    local currentTime = tick()
+    local currentTime = time()
     local recentErrors = 0
     
     for _, timestamps in pairs(self.errorTimestamps) do
@@ -633,7 +633,7 @@ end
 
 -- Clean up old errors
 function EnhancedErrorHandler:CleanupOldErrors()
-    local currentTime = tick()
+    local currentTime = time()
     local cutoffTime = currentTime - 3600 -- 1 hour
     
     -- Clean up old error timestamps
@@ -714,7 +714,7 @@ end
 
 -- Get recent error count
 function EnhancedErrorHandler:GetRecentErrorCount()
-    local currentTime = tick()
+    local currentTime = time()
     local recentCount = 0
     
     for _, timestamps in pairs(self.errorTimestamps) do

--- a/src/Utils/EnhancedMemoryManager.lua
+++ b/src/Utils/EnhancedMemoryManager.lua
@@ -100,7 +100,7 @@ function EnhancedMemoryManager.new()
     self.leakDetection = {
         growthHistory = {},           -- Memory growth over time
         objectCounts = {},            -- Object counts by category
-        lastCleanup = tick(),         -- Last cleanup time
+        lastCleanup = time(),         -- Last cleanup time
         leakThresholds = {            -- Leak detection thresholds
             maxGrowthRate = 10 * 1024 * 1024, -- 10MB per hour
             maxObjectCount = 10000,            -- Max objects per category
@@ -180,7 +180,7 @@ function EnhancedMemoryManager:SetupMemoryMonitoring()
     -- Monitor memory usage every second
     self._lastMemoryUsageUpdate = 0
     RunService.Heartbeat:Connect(function()
-        local currentTime = tick()
+        local currentTime = time()
         if currentTime - (self._lastMemoryUsageUpdate or 0) >= 1 then -- Every second
             self._lastMemoryUsageUpdate = currentTime
             self:UpdateMemoryUsage()
@@ -190,7 +190,7 @@ function EnhancedMemoryManager:SetupMemoryMonitoring()
     -- Check for memory issues every 5 seconds
     self._lastMemoryHealthCheck = 0
     RunService.Heartbeat:Connect(function()
-        local currentTime = tick()
+        local currentTime = time()
         if currentTime - (self._lastMemoryHealthCheck or 0) >= 5 then -- Every 5 seconds
             self._lastMemoryHealthCheck = currentTime
             self:CheckMemoryHealth()
@@ -206,7 +206,7 @@ function EnhancedMemoryManager:SetupConnectionTracking()
     Players.PlayerAdded:Connect(function(player)
         self.connectionTracker[player.UserId] = {
             connections = {},
-            lastUpdate = tick(),
+            lastUpdate = time(),
             totalConnections = 0
         }
     end)
@@ -222,7 +222,7 @@ function EnhancedMemoryManager:SetupPeriodicCleanup()
     if not self.autoCleanupEnabled then return end
     
     RunService.Heartbeat:Connect(function()
-        local currentTime = tick()
+        local currentTime = time()
         
         -- Clean up connections
         if currentTime - (self.lastCleanup.CONNECTIONS or 0) >= MEMORY_CONFIG.CLEANUP_INTERVALS.CONNECTIONS then
@@ -274,7 +274,7 @@ function EnhancedMemoryManager:SetupLeakDetection()
     
     -- Set up periodic leak detection
     RunService.Heartbeat:Connect(function()
-        local currentTime = tick()
+        local currentTime = time()
         if currentTime - self.leakDetection.lastCleanup >= MEMORY_CONFIG.CLEANUP_INTERVALS.LEAK_DETECTION then
             self:DetectMemoryLeaks()
             self.leakDetection.lastCleanup = currentTime
@@ -290,7 +290,7 @@ function EnhancedMemoryManager:SetupUsagePrediction()
     
     -- Set up periodic prediction updates
     RunService.Heartbeat:Connect(function()
-        local currentTime = tick()
+        local currentTime = time()
         if currentTime - self.usagePrediction.nextPrediction >= 300 then -- Every 5 minutes
             self:UpdateUsagePredictions()
             self.usagePrediction.nextPrediction = currentTime
@@ -306,7 +306,7 @@ function EnhancedMemoryManager:SetupSecurityIntegration()
     
     -- Set up periodic security checks
     RunService.Heartbeat:Connect(function()
-        local currentTime = tick()
+        local currentTime = time()
         if currentTime - self.securityIntegration.lastSecurityCheck >= 120 then -- Every 2 minutes
             self:CheckSecurityMemoryPatterns()
             self.securityIntegration.lastSecurityCheck = currentTime
@@ -322,7 +322,7 @@ function EnhancedMemoryManager:InitializeMemoryCategories()
         self.memoryUsage[category] = {
             current = 0,
             peak = 0,
-            lastUpdate = tick()
+            lastUpdate = time()
         }
         
         self.lastCleanup[category] = 0
@@ -337,7 +337,7 @@ function EnhancedMemoryManager:TrackConnection(player, connection, metadata)
     if not self.connectionTracker[player.UserId] then
         self.connectionTracker[player.UserId] = {
             connections = {},
-            lastUpdate = tick(),
+            lastUpdate = time(),
             totalConnections = 0
         }
     end
@@ -354,13 +354,13 @@ function EnhancedMemoryManager:TrackConnection(player, connection, metadata)
     local connectionInfo = {
         connection = connection,
         metadata = metadata or {},
-        timestamp = tick(),
+        timestamp = time(),
         id = HttpService:GenerateGUID()
     }
     
     table.insert(playerData.connections, connectionInfo)
     playerData.totalConnections = playerData.totalConnections + 1
-    playerData.lastUpdate = tick()
+    playerData.lastUpdate = time()
     
     -- Track object for cleanup
     self:TrackObject(connection, {
@@ -380,8 +380,8 @@ function EnhancedMemoryManager:TrackObject(object, metadata)
     self.objectTracker[objectId] = {
         object = object,
         metadata = metadata or {},
-        timestamp = tick(),
-        lastAccess = tick(),
+        timestamp = time(),
+        lastAccess = time(),
         accessCount = 0
     }
     
@@ -398,7 +398,7 @@ function EnhancedMemoryManager:UpdateObjectMemoryUsage(object, metadata)
         self.memoryUsage[category] = {
             current = 0,
             peak = 0,
-            lastUpdate = tick()
+            lastUpdate = time()
         }
     end
     
@@ -408,7 +408,7 @@ function EnhancedMemoryManager:UpdateObjectMemoryUsage(object, metadata)
         self.memoryUsage[category].peak = self.memoryUsage[category].current
     end
     
-    self.memoryUsage[category].lastUpdate = tick()
+    self.memoryUsage[category].lastUpdate = time()
 end
 
 -- Estimate object memory size
@@ -462,7 +462,7 @@ function EnhancedMemoryManager:UpdateMemoryUsage()
         
         table.insert(self.memoryHistory[category], {
             usage = data.current,
-            timestamp = tick()
+            timestamp = time()
         })
         
         -- Keep only last 100 entries
@@ -491,7 +491,7 @@ function EnhancedMemoryManager:HandleMemoryWarning(totalMemory)
     local alert = {
         level = "WARNING",
         message = "Memory usage is high: " .. self:FormatBytes(totalMemory),
-        timestamp = tick(),
+        timestamp = time(),
         action = "Monitor closely"
     }
     
@@ -507,7 +507,7 @@ function EnhancedMemoryManager:HandleMemoryCritical(totalMemory)
     local alert = {
         level = "CRITICAL",
         message = "Memory usage is critical: " .. self:FormatBytes(totalMemory),
-        timestamp = tick(),
+        timestamp = time(),
         action = "Aggressive cleanup required"
     }
     
@@ -523,7 +523,7 @@ function EnhancedMemoryManager:HandleMemoryEmergency(totalMemory)
     local alert = {
         level = "EMERGENCY",
         message = "Memory usage is emergency level: " .. self:FormatBytes(totalMemory),
-        timestamp = tick(),
+        timestamp = time(),
         action = "Emergency cleanup and optimization"
     }
     
@@ -559,7 +559,7 @@ end
 
 -- NEW: Comprehensive memory leak detection
 function EnhancedMemoryManager:DetectMemoryLeaks()
-    local currentTime = tick()
+    local currentTime = time()
     local leaksDetected = 0
     
     -- Check for unbounded growth in tracking systems
@@ -619,7 +619,7 @@ function EnhancedMemoryManager:CalculateGrowthRate(category, windowSeconds)
         return 0
     end
     
-    local currentTime = tick()
+    local currentTime = time()
     local windowStart = currentTime - windowSeconds
     
     -- Find data points within the window
@@ -650,7 +650,7 @@ end
 
 -- NEW: Detect leaks based on object count growth
 function EnhancedMemoryManager:DetectObjectCountLeaks()
-    local currentTime = tick()
+    local currentTime = time()
     local currentObjectCount = self:GetTotalObjectCount()
     
     if not self.leakDetection.objectCounts.lastCount then
@@ -703,7 +703,7 @@ function EnhancedMemoryManager:PredictMemoryUsage(category)
     end
     
     local dataPoints = self.memoryHistory[category]
-    local currentTime = tick()
+    local currentTime = time()
     
     -- Simple linear regression for prediction
     local sumX = 0
@@ -763,7 +763,7 @@ end
 
 -- NEW: Check security-related memory patterns
 function EnhancedMemoryManager:CheckSecurityMemoryPatterns()
-    local currentTime = tick()
+    local currentTime = time()
     
     -- Check for unusual memory patterns that might indicate security issues
     for category, data in pairs(self.memoryUsage) do
@@ -849,7 +849,7 @@ function EnhancedMemoryManager:CleanupConnections()
             self.connectionTracker[userId] = nil
         else
             -- Clean up old connections
-            local currentTime = tick()
+            local currentTime = time()
             for i = #playerData.connections, 1, -1 do
                 local connectionInfo = playerData.connections[i]
                 
@@ -924,7 +924,7 @@ function EnhancedMemoryManager:PerformFullCleanup()
     print("Performing full memory cleanup...")
     
     -- Clean up old objects
-    local currentTime = tick()
+    local currentTime = time()
     local cleanedCount = 0
     
     for objectId, objectInfo in pairs(self.objectTracker) do
@@ -1003,7 +1003,7 @@ function EnhancedMemoryManager:TriggerMemoryOptimization()
     
     -- Record optimization event
     table.insert(self.optimizationEvents, {
-        timestamp = tick(),
+        timestamp = time(),
         type = "MEMORY_OPTIMIZATION",
         description = "Automatic memory optimization triggered"
     })
@@ -1164,7 +1164,7 @@ function EnhancedMemoryManager:GetLeakDetectionStats()
         objectGrowth = self.leakDetection.objectCounts
     }
     
-    local oneHourAgo = tick() - 3600
+    local oneHourAgo = time() - 3600
     
     for _, alert in ipairs(self.leakDetection.leakAlerts) do
         if alert.severity == "HIGH" then
@@ -1211,7 +1211,7 @@ function EnhancedMemoryManager:GetSecurityMemoryStats()
         highSeverityEvents = 0
     }
     
-    local oneHourAgo = tick() - 3600
+    local oneHourAgo = time() - 3600
     
     for _, event in ipairs(self.securityIntegration.securityEvents) do
         if event.timestamp > oneHourAgo then
@@ -1278,7 +1278,7 @@ end
 function EnhancedMemoryManager:GetMemoryTrendAnalysis(category, hours)
     hours = hours or 24
     local seconds = hours * 3600
-    local currentTime = tick()
+    local currentTime = time()
     local windowStart = currentTime - seconds
     
     if not self.memoryHistory[category] then
@@ -1516,7 +1516,7 @@ end
 -- NEW: Get comprehensive system report
 function EnhancedMemoryManager:GetComprehensiveReport()
     local report = {
-        timestamp = tick(),
+        timestamp = time(),
         memoryStats = self:GetEnhancedMemoryStats(),
         leakDetection = self:GetLeakDetectionStats(),
         security = self:GetSecurityMemoryStats(),
@@ -1580,7 +1580,7 @@ function EnhancedMemoryManager:RecordMemoryLeak(category, leakType, details)
         category = category,
         leakType = leakType,
         severity = self:CalculateLeakSeverity(leakType, details),
-        timestamp = tick(),
+        timestamp = time(),
         details = details,
         message = self:GenerateLeakMessage(leakType, details)
     }
@@ -1598,7 +1598,7 @@ function EnhancedMemoryManager:RecordMemoryLeak(category, leakType, details)
     -- Add to suspicious objects
     self.leakDetection.suspiciousObjects[category] = {
         leakType = leakType,
-        firstDetected = tick(),
+        firstDetected = time(),
         occurrences = (self.leakDetection.suspiciousObjects[category] and 
                       self.leakDetection.suspiciousObjects[category].occurrences or 0) + 1
     }
@@ -1660,7 +1660,7 @@ end
 
 -- Clear old data
 function EnhancedMemoryManager:ClearOldData()
-    local currentTime = tick()
+    local currentTime = time()
     
     -- Clear old position data
     for userId, playerData in pairs(self.positionTracker or {}) do

--- a/src/Utils/EnhancedOptimizationValidator.lua
+++ b/src/Utils/EnhancedOptimizationValidator.lua
@@ -113,14 +113,14 @@ function EnhancedOptimizationValidator:initializeValidationSystems()
     
     -- Memory monitoring
     self.memoryConnection = RunService.Heartbeat:Connect(function()
-        if tick() % 3 < 0.1 then
+        if time() % 3 < 0.1 then
             self:updateMemoryMetrics()
         end
     end)
     
     -- Object monitoring
     self.objectConnection = RunService.Heartbeat:Connect(function()
-        if tick() % 5 < 0.1 then
+        if time() % 5 < 0.1 then
             self:updateObjectMetrics()
         end
     end)
@@ -187,7 +187,7 @@ function EnhancedOptimizationValidator:assessDeviceCapabilities()
     
     -- Frame rate capability test
     local frameRateSamples = {}
-    local startTime = tick()
+    local startTime = time()
     local sampleCount = 0
     
     local frameRateTest = nil
@@ -195,7 +195,7 @@ function EnhancedOptimizationValidator:assessDeviceCapabilities()
         sampleCount = sampleCount + 1
         frameRateSamples[sampleCount] = 1 / RunService.Heartbeat:Wait()
         
-        if tick() - startTime >= 8 then -- 8 second test
+        if time() - startTime >= 8 then -- 8 second test
             if frameRateTest then
                 frameRateTest:Disconnect()
             end
@@ -302,7 +302,7 @@ function EnhancedOptimizationValidator:startValidation(validationName)
     print("=" .. string.rep("=", 70))
     
     isRunning = true
-    testStartTime = tick()
+    testStartTime = time()
     currentTest = {
         name = validationName,
         startTime = testStartTime,
@@ -354,14 +354,14 @@ end
 function EnhancedOptimizationValidator:runBaselineTest()
     print("📊 Phase 1: Running baseline performance test...")
     
-    local baselineStart = tick()
+    local baselineStart = time()
     local baselineSamples = {}
     
     -- Collect baseline samples
     local baselineConnection = nil
     baselineConnection = RunService.Heartbeat:Connect(function(deltaTime)
         local sample = {
-                    timestamp = tick(),
+                    timestamp = time(),
         frameRate = 1 / deltaTime,
         updateTime = deltaTime * 1000,
         memoryUsage = game:GetService("Stats").PhysicalMemory,
@@ -371,7 +371,7 @@ function EnhancedOptimizationValidator:runBaselineTest()
         
         table.insert(baselineSamples, sample)
         
-        if tick() - baselineStart >= VALIDATION_CONFIG.BASELINE_DURATION then
+        if time() - baselineStart >= VALIDATION_CONFIG.BASELINE_DURATION then
             if baselineConnection then
                 baselineConnection:Disconnect()
             end
@@ -480,7 +480,7 @@ end
     Run single optimization test
 ]]
 function EnhancedOptimizationValidator:runSingleOptimizationTest(testNumber)
-    local testStart = tick()
+    local testStart = time()
     local testSamples = {}
     
     -- Simulate optimization activation
@@ -493,7 +493,7 @@ function EnhancedOptimizationValidator:runSingleOptimizationTest(testNumber)
     local testConnection = nil
     testConnection = RunService.Heartbeat:Connect(function(deltaTime)
         local sample = {
-            timestamp = tick(),
+            timestamp = time(),
             frameRate = 1 / deltaTime,
             updateTime = deltaTime * 1000,
             memoryUsage = game:GetService("Stats").PhysicalMemory,
@@ -503,7 +503,7 @@ function EnhancedOptimizationValidator:runSingleOptimizationTest(testNumber)
         
         table.insert(testSamples, sample)
         
-        if tick() - testStart >= VALIDATION_CONFIG.TEST_DURATION then
+        if time() - testStart >= VALIDATION_CONFIG.TEST_DURATION then
             if testConnection then
                 testConnection:Disconnect()
             end
@@ -541,7 +541,7 @@ function EnhancedOptimizationValidator:simulateOptimizationActivation()
     
     -- Store optimization action
     table.insert(optimizationHistory, {
-        timestamp = tick(),
+        timestamp = time(),
         strategy = randomStrategy,
         deviceProfile = deviceProfile
     })
@@ -608,7 +608,7 @@ end
     Test specific optimization strategy
 ]]
 function EnhancedOptimizationValidator:testOptimizationStrategy(strategy)
-    local testStart = tick()
+    local testStart = time()
     local testSamples = {}
     
     -- Simulate strategy activation
@@ -621,7 +621,7 @@ function EnhancedOptimizationValidator:testOptimizationStrategy(strategy)
     local testConnection = nil
     testConnection = RunService.Heartbeat:Connect(function(deltaTime)
         local sample = {
-            timestamp = tick(),
+            timestamp = time(),
             frameRate = 1 / deltaTime,
             updateTime = deltaTime * 1000,
             memoryUsage = game:GetService("Stats").PhysicalMemory,
@@ -631,7 +631,7 @@ function EnhancedOptimizationValidator:testOptimizationStrategy(strategy)
         
         table.insert(testSamples, sample)
         
-        if tick() - testStart >= VALIDATION_CONFIG.TEST_DURATION then
+        if time() - testStart >= VALIDATION_CONFIG.TEST_DURATION then
             if testConnection then
                 testConnection:Disconnect()
             end
@@ -703,7 +703,7 @@ function EnhancedOptimizationValidator:detectPerformanceRegressions()
         if test.improvement and test.improvement.overall then
             if test.improvement.overall < VALIDATION_CONFIG.PERFORMANCE_THRESHOLDS.MAX_REGRESSION then
                 local regression = {
-                    timestamp = tick(),
+                    timestamp = time(),
                     testType = "Optimization Test",
                     severity = "High",
                     description = "Performance regression detected in optimization test",
@@ -725,7 +725,7 @@ function EnhancedOptimizationValidator:detectPerformanceRegressions()
         if test.improvement and test.improvement.overall then
             if test.improvement.overall < VALIDATION_CONFIG.PERFORMANCE_THRESHOLDS.MAX_REGRESSION then
                 local regression = {
-                    timestamp = tick(),
+                    timestamp = time(),
                     testType = "Strategy Test: " .. test.strategy,
                     severity = "Medium",
                     description = "Performance regression detected in strategy test",
@@ -895,7 +895,7 @@ function EnhancedOptimizationValidator:completeValidation(recommendations)
         effectivenessScores = validationResults.effectivenessScores[#validationResults.effectivenessScores]
     }
     
-    currentTest.endTime = tick()
+    currentTest.endTime = time()
     currentTest.duration = currentTest.endTime - currentTest.startTime
     
     -- Store validation history
@@ -972,7 +972,7 @@ end
 function EnhancedOptimizationValidator:updatePerformanceMetrics(deltaTime)
     -- Update performance metrics
     local sample = {
-        timestamp = tick(),
+        timestamp = time(),
         frameRate = 1 / deltaTime,
         updateTime = deltaTime * 1000
     }
@@ -1032,7 +1032,7 @@ function EnhancedOptimizationValidator:getValidationStatus()
     return {
         isRunning = isRunning,
         currentTest = currentTest,
-        elapsedTime = isRunning and (tick() - testStartTime) or 0,
+        elapsedTime = isRunning and (time() - testStartTime) or 0,
         deviceProfile = deviceProfile
     }
 end

--- a/src/Utils/EnhancedSecurityManager.lua
+++ b/src/Utils/EnhancedSecurityManager.lua
@@ -253,7 +253,7 @@ end
 function EnhancedSecurityManager:SetupPeriodicChecks()
     -- Run security checks every 5 seconds (stable timer, no modulo)
     RunService.Heartbeat:Connect(function()
-        local currentTime = tick()
+        local currentTime = time()
         if currentTime - (self.lastPeriodicSecurityCheck or 0) >= 5 then
             self.lastPeriodicSecurityCheck = currentTime
             self:RunSecurityChecks()
@@ -298,7 +298,7 @@ function EnhancedSecurityManager:CheckRateLimit(player, action)
     if not rateLimiter then return true end
     
     local playerData = rateLimiter.players[player.UserId]
-    local currentTime = tick()
+    local currentTime = time()
     
     if not playerData then
         playerData = { calls = {}, lastReset = currentTime }
@@ -619,11 +619,11 @@ function EnhancedSecurityManager:TrackPlayerPosition(player)
     local playerData = self.positionTracker[player.UserId]
     
     if not playerData then
-        playerData = { positions = {}, lastUpdate = tick() }
+        playerData = { positions = {}, lastUpdate = time() }
         self.positionTracker[player.UserId] = playerData
     end
     
-    local currentTime = tick()
+    local currentTime = time()
     local timeSinceLastUpdate = currentTime - playerData.lastUpdate
     
     if timeSinceLastUpdate > 0.1 then -- Update every 100ms
@@ -682,7 +682,7 @@ function EnhancedSecurityManager:RecordViolation(player, violationType, details)
     
     local violation = {
         type = violationType,
-        timestamp = tick(),
+        timestamp = time(),
         details = details or {}
     }
     
@@ -700,7 +700,7 @@ function EnhancedSecurityManager:RecordViolation(player, violationType, details)
         self.suspiciousPlayers[player.UserId] = {
             player = player,
             violations = playerData.violations,
-            monitoringStart = tick()
+            monitoringStart = time()
         }
     end
 end
@@ -753,7 +753,7 @@ function EnhancedSecurityManager:ApplyPermanentBan(player)
     if player then
         self.blacklistedPlayers[player.UserId] = {
             reason = "Multiple security violations",
-            timestamp = tick()
+            timestamp = time()
         }
         pcall(function()
             player:Kick("You have been permanently banned due to multiple security violations.")
@@ -787,7 +787,7 @@ end
 -- Log security event
 function EnhancedSecurityManager:LogSecurityEvent(player, eventType, details)
     local logEntry = {
-        timestamp = tick(),
+        timestamp = time(),
         player = (player and player.Name) or "Unknown",
         userId = (player and player.UserId) or -1,
         eventType = eventType,
@@ -821,7 +821,7 @@ end
 
 -- Clean up old data
 function EnhancedSecurityManager:CleanupOldData()
-    local currentTime = tick()
+    local currentTime = time()
     
     -- Clean up old position data
     for userId, playerData in pairs(self.positionTracker) do
@@ -902,7 +902,7 @@ function EnhancedSecurityManager:BlacklistPlayer(adminPlayer, targetPlayer, reas
     self.blacklistedPlayers[targetPlayer.UserId] = {
         reason = reason,
         admin = adminPlayer.Name,
-        timestamp = tick()
+        timestamp = time()
     }
     
     targetPlayer:Kick("You have been blacklisted: " .. reason)

--- a/src/Utils/ErrorHandler.lua
+++ b/src/Utils/ErrorHandler.lua
@@ -65,9 +65,9 @@ local CONFIG = {
 -- Error context information
 local function getErrorContext()
     local context = {
-        timestamp = tick(),
+        timestamp = time(),
         stackTrace = debug.traceback(),
-        gameTime = tick(),
+        gameTime = time(),
         memoryUsage = 0, -- Will be populated if available
         playerCount = 0,  -- Will be populated if available
         serverLoad = 0    -- Will be populated if available
@@ -108,7 +108,7 @@ local function createErrorEntry(errorType, message, severity, category, context,
         category = category or ERROR_CATEGORIES.UNKNOWN,
         context = context or getErrorContext(),
         stackTrace = stackTrace or debug.traceback(),
-        timestamp = tick(),
+        timestamp = time(),
         handled = false,
         recovered = false,
         recoveryAttempts = 0
@@ -182,7 +182,7 @@ local function updateErrorTracking(errorEntry)
     end
     
     -- Update last error time
-    errorState.lastErrorTime = tick()
+    errorState.lastErrorTime = time()
     
     -- Update system health
     if errorEntry.severity >= ERROR_SEVERITY.CRITICAL then
@@ -462,7 +462,7 @@ function ErrorHandler.GetSystemHealth()
     }
     
     -- Calculate error rates
-    local currentTime = tick()
+    local currentTime = time()
     local timeWindow = 3600 -- 1 hour
     
     if currentTime - errorState.lastErrorTime < timeWindow then
@@ -535,7 +535,7 @@ function ErrorHandler.Initialize()
             wait(CONFIG.ERROR_CLEANUP_INTERVAL)
             
             -- Clean up old errors
-            local currentTime = tick()
+            local currentTime = time()
             local cutoffTime = currentTime - 86400 -- 24 hours
             
             for i = #errorState.recentErrors, 1, -1 do

--- a/src/Utils/HelperFunctions.lua
+++ b/src/Utils/HelperFunctions.lua
@@ -341,11 +341,11 @@ end
 function HelperFunctions.MeasurePerformance(func, iterations)
     iterations = iterations or 1000
     
-    local startTime = tick()
+    local startTime = time()
     for i = 1, iterations do
         func()
     end
-    local endTime = tick()
+    local endTime = time()
     
     local totalTime = endTime - startTime
     local averageTime = totalTime / iterations
@@ -480,7 +480,7 @@ function HelperFunctions.ThrottleFunction(func, delay)
     local lastCall = 0
     
     return function(...)
-        local currentTime = tick()
+        local currentTime = time()
         if currentTime - lastCall >= delay then
             lastCall = currentTime
             return func(...)

--- a/src/Utils/PerformanceOptimizer.lua
+++ b/src/Utils/PerformanceOptimizer.lua
@@ -134,21 +134,21 @@ function PerformanceOptimizer:initializeOptimizationSystems()
     
     -- Memory monitoring
     self.memoryConnection = RunService.Heartbeat:Connect(function()
-        if tick() % OPTIMIZATION_CONFIG.MEMORY_CHECK_INTERVAL < 0.1 then
+        if time() % OPTIMIZATION_CONFIG.MEMORY_CHECK_INTERVAL < 0.1 then
             self:updateMemoryMetrics()
         end
     end)
     
     -- Object counting
     self.objectCountConnection = RunService.Heartbeat:Connect(function()
-        if tick() % OPTIMIZATION_CONFIG.PERFORMANCE_CHECK_INTERVAL < 0.1 then
+        if time() % OPTIMIZATION_CONFIG.PERFORMANCE_CHECK_INTERVAL < 0.1 then
             self:updateObjectMetrics()
         end
     end)
     
     -- Cleanup scheduling
     self.cleanupConnection = RunService.Heartbeat:Connect(function()
-        if tick() % OPTIMIZATION_CONFIG.CLEANUP_INTERVAL < 0.1 then
+        if time() % OPTIMIZATION_CONFIG.CLEANUP_INTERVAL < 0.1 then
             self:performMemoryCleanup()
         end
     end)
@@ -168,7 +168,7 @@ function PerformanceOptimizer:setupPerformanceMonitoring()
     
     -- Network performance monitoring
     self.networkConnection = RunService.Heartbeat:Connect(function()
-        if tick() % 2 < 0.1 then
+        if time() % 2 < 0.1 then
             self:updateNetworkMetrics()
         end
     end)
@@ -198,7 +198,7 @@ end
 ]]
 function PerformanceOptimizer:startOptimizationLoop()
     self.optimizationConnection = RunService.Heartbeat:Connect(function()
-        if tick() % OPTIMIZATION_CONFIG.OPTIMIZATION_CHECK_INTERVAL < 0.1 then
+        if time() % OPTIMIZATION_CONFIG.OPTIMIZATION_CHECK_INTERVAL < 0.1 then
             self:checkAndOptimize()
         end
     end)
@@ -221,11 +221,11 @@ function PerformanceOptimizer:updatePerformanceMetrics(deltaTime)
     end
     
     -- Update time tracking
-    currentMetrics.updateTime = tick()
+    currentMetrics.updateTime = time()
     
     -- Store performance history
     table.insert(performanceState.performanceHistory, {
-        timestamp = tick(),
+        timestamp = time(),
         frameRate = currentMetrics.frameRate,
         frameTime = currentMetrics.frameTime,
         memoryUsage = currentMetrics.memoryUsage,
@@ -249,7 +249,7 @@ function PerformanceOptimizer:updateMemoryMetrics()
     
     -- Store memory history
     table.insert(performanceState.memoryHistory, {
-        timestamp = tick(),
+        timestamp = time(),
         total = memoryStats.total,
         byCategory = memoryStats.byCategory,
         growth = memoryStats.growth
@@ -275,7 +275,7 @@ function PerformanceOptimizer:updateObjectMetrics()
     
     -- Store object metrics
     table.insert(performanceState.drawCallHistory, {
-        timestamp = tick(),
+        timestamp = time(),
         objectCount = objectCount,
         drawCalls = drawCalls
     })
@@ -371,7 +371,7 @@ function PerformanceOptimizer:performOptimization()
     
     if success then
         performanceState.optimizationCount = performanceState.optimizationCount + 1
-        performanceState.lastOptimization = tick()
+        performanceState.lastOptimization = time()
         print("PerformanceOptimizer: Optimization applied successfully -", strategy)
     else
         print("PerformanceOptimizer: Optimization failed -", strategy)
@@ -643,7 +643,7 @@ function PerformanceOptimizer:cleanupTemporaryObjects()
     -- Clean up temporary objects in workspace
     for _, child in pairs(Workspace:GetChildren()) do
         if child.Name:find("Temp") or child.Name:find("Temporary") then
-            if tick() - (child:GetAttribute("CreatedAt") or 0) > 60 then
+            if time() - (child:GetAttribute("CreatedAt") or 0) > 60 then
                 child:Destroy()
             end
         end

--- a/src/Utils/PerformanceTestSuite.lua
+++ b/src/Utils/PerformanceTestSuite.lua
@@ -90,7 +90,7 @@ function PerformanceTestSuite:initializePerformanceMonitoring()
     -- Memory monitoring
     self._lastMemoryMetricsUpdate = 0
     self.memoryConnection = RunService.Heartbeat:Connect(function()
-        local now = tick()
+        local now = time()
         if now - (self._lastMemoryMetricsUpdate or 0) >= (TEST_CONFIG.MEMORY_CHECK_INTERVAL or 3) then
             self._lastMemoryMetricsUpdate = now
             self:updateMemoryMetrics()
@@ -100,7 +100,7 @@ function PerformanceTestSuite:initializePerformanceMonitoring()
     -- Object counting
     self._lastObjectCountUpdate = 0
     self.objectCountConnection = RunService.Heartbeat:Connect(function()
-        local now = tick()
+        local now = time()
         if now - (self._lastObjectCountUpdate or 0) >= 10 then
             self._lastObjectCountUpdate = now
             self:updateObjectCounts()
@@ -163,7 +163,7 @@ function PerformanceTestSuite:updateMemoryMetrics()
     
     -- Store sample for analysis
     table.insert(memorySamples, {
-        time = tick(),
+        time = time(),
         usage = memory
     })
     
@@ -224,7 +224,7 @@ function PerformanceTestSuite:runBenchmark()
     
     print("🚀 Starting comprehensive performance benchmark...")
     isRunning = true
-    testStartTime = tick()
+    testStartTime = time()
     
     -- Clear previous samples
     frameRateSamples = {}
@@ -233,7 +233,7 @@ function PerformanceTestSuite:runBenchmark()
     -- Run benchmark for specified duration
     local benchmarkConnection
     benchmarkConnection = RunService.Heartbeat:Connect(function()
-        local elapsed = tick() - testStartTime
+        local elapsed = time() - testStartTime
         
         if elapsed >= TEST_CONFIG.BENCHMARK_DURATION then
             benchmarkConnection:Disconnect()
@@ -263,7 +263,7 @@ function PerformanceTestSuite:completeBenchmark()
     
     -- Store results
     testResults.benchmarks[#testResults.benchmarks + 1] = {
-        timestamp = tick(),
+        timestamp = time(),
         frameRate = frameRateResults,
         memory = memoryResults,
         objects = objectResults,
@@ -512,7 +512,7 @@ function PerformanceTestSuite:runMemoryTest()
     
     print("🧠 Starting memory leak detection test...")
     isRunning = true
-    testStartTime = tick()
+    testStartTime = time()
     
     -- Clear previous samples
     memorySamples = {}
@@ -533,7 +533,7 @@ function PerformanceTestSuite:runMemoryTest()
     -- Monitor memory for extended period
     local memoryTestConnection
     memoryTestConnection = RunService.Heartbeat:Connect(function()
-        local elapsed = tick() - testStartTime
+        local elapsed = time() - testStartTime
         
         if elapsed >= 60 then
             memoryTestConnection:Disconnect()
@@ -560,7 +560,7 @@ function PerformanceTestSuite:completeMemoryTest(testObjects)
     
     -- Store results
     testResults.memoryTests[#testResults.memoryTests + 1] = {
-        timestamp = tick(),
+        timestamp = time(),
         results = memoryResults,
         duration = 60
     }
@@ -588,7 +588,7 @@ function PerformanceTestSuite:generateReport()
     print("📊 Generating comprehensive performance test report...")
     
     local report = {
-        timestamp = tick(),
+        timestamp = time(),
         summary = {},
         detailedResults = testResults,
         recommendations = {}

--- a/src/Utils/ProductionModeManager.lua
+++ b/src/Utils/ProductionModeManager.lua
@@ -15,7 +15,7 @@ function ProductionModeManager.new()
     
     self.isProductionMode = Constants.PRODUCTION.ENABLED
     self.optimizationLevel = "NORMAL"
-    self.lastOptimization = tick()
+    self.lastOptimization = time()
     self.performanceMetrics = {}
     self.optimizationHistory = {}
     
@@ -65,7 +65,7 @@ function ProductionModeManager:SetupProductionMonitoring()
     
     -- Monitor performance metrics
     RunService.Heartbeat:Connect(function()
-        local currentTime = tick()
+        local currentTime = time()
         if currentTime - (self.lastOptimization or 0) >= Constants.PRODUCTION.MONITORING.METRICS_INTERVAL then
             self:UpdatePerformanceMetrics()
             self:CheckOptimizationNeeds()
@@ -78,7 +78,7 @@ end
 
 -- Update performance metrics
 function ProductionModeManager:UpdatePerformanceMetrics()
-    local currentTime = tick()
+    local currentTime = time()
     
     -- Get current performance data
     local memoryUsage = self:GetMemoryUsage()
@@ -130,7 +130,7 @@ end
 
 -- Trigger optimization
 function ProductionModeManager:TriggerOptimization(optimizationType)
-    local currentTime = tick()
+    local currentTime = time()
     
     print("PRODUCTION MODE: Triggering " .. optimizationType .. " optimization")
     
@@ -228,7 +228,7 @@ end
 -- Log production alert
 function ProductionModeManager:LogProductionAlert(alert)
     local logEntry = {
-        timestamp = tick(),
+        timestamp = time(),
         alert = alert,
         metrics = self.performanceMetrics
     }
@@ -263,7 +263,7 @@ end
 function ProductionModeManager:EnableAggressiveMemoryCleanup()
     -- Set up more frequent cleanup (Roblox handles garbage collection automatically)
     RunService.Heartbeat:Connect(function()
-        local currentTime = tick()
+        local currentTime = time()
         if currentTime % Constants.PRODUCTION.MEMORY.CLEANUP_INTERVAL < 0.1 then
             task.wait() -- Allow frame to complete
         end

--- a/src/Utils/SecurityWrapper.lua
+++ b/src/Utils/SecurityWrapper.lua
@@ -50,7 +50,7 @@ local securityState = {
     blockedPlayers = {},      -- Temporarily blocked players
     securityLogs = {},        -- Security event logs
     rateLimitCounters = {},   -- Rate limiting counters
-    lastCleanup = tick()      -- Last cleanup time
+    lastCleanup = time()      -- Last cleanup time
 }
 
 -- Security event types
@@ -188,7 +188,7 @@ end
 -- Check rate limiting for a player
 function SecurityWrapper.CheckRateLimit(player, eventName, rateLimit)
     local userId = player.UserId
-    local currentTime = tick()
+    local currentTime = time()
     
     -- Initialize player tracking if needed
     if not securityState.rateLimitCounters[userId] then
@@ -280,7 +280,7 @@ end
 -- Detect suspicious activity
 function SecurityWrapper.DetectSuspiciousActivity(player, eventName, args)
     local userId = player.UserId
-    local currentTime = tick()
+    local currentTime = time()
     
     -- Initialize player tracking
     if not securityState.playerRequests[userId] then
@@ -332,7 +332,7 @@ end
 -- Log security events
 function SecurityWrapper.LogSecurityEvent(eventType, player, details)
     local logEntry = {
-        timestamp = tick(),
+        timestamp = time(),
         eventType = eventType,
         playerId = player.UserId,
         playerName = player.Name,
@@ -382,7 +382,7 @@ function SecurityWrapper.GetSecurityMetrics()
     end
     
     -- Count recent events (last hour)
-    local oneHourAgo = tick() - 3600
+    local oneHourAgo = time() - 3600
     for _, logEntry in ipairs(securityState.securityLogs) do
         if logEntry.timestamp > oneHourAgo then
             metrics.recentSecurityEvents = metrics.recentSecurityEvents + 1
@@ -394,7 +394,7 @@ end
 
 -- Cleanup old data
 function SecurityWrapper.Cleanup()
-    local currentTime = tick()
+    local currentTime = time()
     
     -- Clean up old rate limit counters
     for userId, eventCounters in pairs(securityState.rateLimitCounters) do

--- a/src/Utils/StandardizedErrorHandler.lua
+++ b/src/Utils/StandardizedErrorHandler.lua
@@ -155,7 +155,7 @@ end
 function StandardizedErrorHandler:CreateErrorObject(error, context)
     local errorObj = {
         id = HttpService:GenerateGUID(),
-        timestamp = tick(),
+        timestamp = time(),
         message = tostring(error),
         category = context.category or ERROR_CATEGORIES.SYSTEM,
         severity = context.severity or ERROR_SEVERITY.MEDIUM,

--- a/src/Utils/UpdateManager.lua
+++ b/src/Utils/UpdateManager.lua
@@ -171,7 +171,7 @@ end
 
 -- Process all updates for current frame
 function UpdateManager:ProcessUpdates(deltaTime)
-    local startTime = tick()
+    local startTime = time()
     local updatesProcessed = 0
     
     -- Process updates by priority
@@ -183,7 +183,7 @@ function UpdateManager:ProcessUpdates(deltaTime)
                     local success, executionTime = self:ExecuteUpdate(updateData, deltaTime)
                     if success then
                         updatesProcessed = updatesProcessed + 1
-                        updateData.lastRun = tick()
+                        updateData.lastRun = time()
                         updateData.executionCount = updateData.executionCount + 1
                         updateData.totalExecutionTime = updateData.totalExecutionTime + executionTime
                         updateData.averageExecutionTime = updateData.totalExecutionTime / updateData.executionCount
@@ -203,7 +203,7 @@ function UpdateManager:ProcessUpdates(deltaTime)
     end
     
     -- Update performance metrics
-    local endTime = tick()
+    local endTime = time()
     local updateTime = endTime - startTime
     
     performanceMetrics.totalUpdates = performanceMetrics.totalUpdates + updatesProcessed
@@ -232,7 +232,7 @@ end
 
 -- Process background updates
 function UpdateManager:ProcessBackgroundUpdates()
-    local startTime = tick()
+    local startTime = time()
     
     -- Process low priority updates
     for priority = UPDATE_PRIORITIES.LOW, UPDATE_PRIORITIES.BACKGROUND do
@@ -241,13 +241,13 @@ function UpdateManager:ProcessBackgroundUpdates()
             for _, updateData in ipairs(updates) do
                 if updateData.isActive and self:ShouldRunUpdate(updateData, 1) then
                     self:ExecuteUpdate(updateData, 1)
-                    updateData.lastRun = tick()
+                    updateData.lastRun = time()
                 end
             end
         end
     end
     
-    local endTime = tick()
+    local endTime = time()
     if endTime - startTime > 0.1 then -- Background updates shouldn't take more than 100ms
         warn("UpdateManager: Background updates took", math.floor((endTime - startTime) * 1000), "ms")
     end
@@ -263,15 +263,15 @@ function UpdateManager:ShouldRunUpdate(updateData, deltaTime)
         return true -- Run every frame
     end
     
-    local currentTime = tick()
+    local currentTime = time()
     return currentTime - updateData.lastRun >= updateData.interval
 end
 
 -- Execute a single update
 function UpdateManager:ExecuteUpdate(updateData, deltaTime)
-    local startTime = tick()
+    local startTime = time()
     local success, result = pcall(updateData.func, deltaTime)
-    local executionTime = tick() - startTime
+    local executionTime = time() - startTime
     
     if not success then
         warn("UpdateManager: Update function error:", result)

--- a/src/World/PlotThemeDecorator.lua
+++ b/src/World/PlotThemeDecorator.lua
@@ -441,11 +441,11 @@ end
 function PlotThemeDecorator:StartPerformanceUpdate()
     debug.setmemorycategory("PerformanceUpdateLoop")
     
-    local lastUpdate = tick()
+    local lastUpdate = time()
     local updateInterval = 1.0 -- Update every second
     
     RunService.Heartbeat:Connect(function()
-        local currentTime = tick()
+        local currentTime = time()
         if currentTime - lastUpdate >= updateInterval then
             self:UpdatePerformanceDisplay()
             lastUpdate = currentTime
@@ -496,7 +496,7 @@ function PlotThemeDecorator:ApplyThemeToPlot(plotId, themeName, options)
         return false, "Theme not found: " .. themeName
     end
     
-    local startTime = tick()
+    local startTime = time()
     
     -- Get plot container from world generator
     local plotContainer = self.worldGenerator:GetPlotContainer(plotId)
@@ -526,7 +526,7 @@ function PlotThemeDecorator:ApplyThemeToPlot(plotId, themeName, options)
     -- Update performance metrics
     performanceMetrics.totalDecorations = performanceMetrics.totalDecorations + self:CountPlotDecorations(plotId)
     performanceMetrics.activeThemes = performanceMetrics.activeThemes + 1
-    performanceMetrics.decorationTime = tick() - startTime
+    performanceMetrics.decorationTime = time() - startTime
     
     print("Applied theme", themeName, "to plot", plotId, "in", performanceMetrics.decorationTime, "seconds")
     return true
@@ -873,7 +873,7 @@ end
 function PlotThemeDecorator:OptimizeDecorations()
     debug.setmemorycategory("DecorationOptimization")
     
-    local optimizationStart = tick()
+    local optimizationStart = time()
     
     -- Apply streaming to all decorations
     for _, container in pairs(activeDecorations) do
@@ -890,7 +890,7 @@ function PlotThemeDecorator:OptimizeDecorations()
     -- Memory cleanup (Roblox handles garbage collection automatically)
     task.wait() -- Allow frame to complete
     
-    local optimizationTime = tick() - optimizationStart
+    local optimizationTime = time() - optimizationStart
     print("Decoration optimization completed in", optimizationTime, "seconds")
 end
 

--- a/src/World/WorldGenerator.lua
+++ b/src/World/WorldGenerator.lua
@@ -115,11 +115,11 @@ end
 function WorldGenerator:StartPerformanceUpdate()
     debug.setmemorycategory("PerformanceUpdateLoop")
     
-    local lastUpdate = tick()
+    local lastUpdate = time()
     local updateInterval = Constants.WORLD_GENERATION.PERFORMANCE.UPDATE_INTERVAL
     
     RunService.Heartbeat:Connect(function()
-        local currentTime = tick()
+        local currentTime = time()
         if currentTime - lastUpdate >= updateInterval then
             self:UpdatePerformanceDisplay()
             lastUpdate = currentTime
@@ -165,7 +165,7 @@ function WorldGenerator:GenerateWorld(options)
         return false, "World generation already in progress"
     end
     
-    local startTime = tick()
+    local startTime = time()
     isGenerating = true
     
     -- Clear existing world
@@ -180,7 +180,7 @@ function WorldGenerator:GenerateWorld(options)
     end)
     
     isGenerating = false
-    performanceMetrics.generationTime = tick() - startTime
+    performanceMetrics.generationTime = time() - startTime
     
     if not success then
         warn("World generation failed:", error)
@@ -501,10 +501,10 @@ function WorldGenerator:CreateDayNightCycle()
     debug.setmemorycategory("DayNightCycle")
     
     local cycleDuration = Constants.WORLD_GENERATION.LIGHTING.DAY_NIGHT_CYCLE_DURATION
-    local startTime = tick()
+    local startTime = time()
     
     RunService.Heartbeat:Connect(function()
-        local elapsed = tick() - startTime
+        local elapsed = time() - startTime
         local cycleProgress = (elapsed % cycleDuration) / cycleDuration
         
         -- Calculate sun position
@@ -535,7 +535,7 @@ end
 function WorldGenerator:OptimizeWorld()
     debug.setmemorycategory("WorldOptimization")
     
-    local optimizationStart = tick()
+    local optimizationStart = time()
     
     -- Combine parts where possible
     self:CombineSimilarParts()
@@ -549,7 +549,7 @@ function WorldGenerator:OptimizeWorld()
     -- Memory cleanup (Roblox handles garbage collection automatically)
     task.wait() -- Allow frame to complete
     
-    local optimizationTime = tick() - optimizationStart
+    local optimizationTime = time() - optimizationStart
     performanceMetrics.lastOptimization = optimizationTime
     
     print("World optimization completed in", optimizationTime, "seconds")

--- a/test_best_practices_implementation.lua
+++ b/test_best_practices_implementation.lua
@@ -126,7 +126,7 @@ local memorySnapshots = {}
 
 local function TakeMemorySnapshot(metrics)
     local snapshot = {
-        timestamp = tick(),
+        timestamp = time(),
         memoryUsage = metrics.memoryUsage,
         systemHealth = metrics.systemHealth,
         playerCount = metrics.playerCount

--- a/test_datastore_integration.lua
+++ b/test_datastore_integration.lua
@@ -62,7 +62,7 @@ if success then
         playerPlots = {
             ["12345"] = {1}
         },
-        timestamp = tick()
+        timestamp = time()
     }
     
     print("   ✅ Test hub data created successfully")

--- a/test_enhanced_memory_system.lua
+++ b/test_enhanced_memory_system.lua
@@ -35,7 +35,7 @@ local function MockRobloxServices()
         end
     }
     
-    _G.tick = function() return os.time() end
+    _G.time = _G.time or os.time
     _G.wait = function() end
     _G.spawn = function(func) func() end
     _G.warn = function(...) print("WARN:", ...) end
@@ -170,14 +170,14 @@ local function TestLeakDetection()
     memoryManager.memoryUsage.SYSTEM_DATA = {
         current = 50 * 1024 * 1024, -- 50MB
         peak = 50 * 1024 * 1024,
-        lastUpdate = tick()
+        lastUpdate = time()
     }
     
     -- Add historical data to simulate growth
     memoryManager.memoryHistory.SYSTEM_DATA = {
-        { usage = 30 * 1024 * 1024, timestamp = tick() - 3600 }, -- 30MB 1 hour ago
-        { usage = 40 * 1024 * 1024, timestamp = tick() - 1800 }, -- 40MB 30 min ago
-        { usage = 50 * 1024 * 1024, timestamp = tick() }         -- 50MB now
+        { usage = 30 * 1024 * 1024, timestamp = time() - 3600 }, -- 30MB 1 hour ago
+        { usage = 40 * 1024 * 1024, timestamp = time() - 1800 }, -- 40MB 30 min ago
+        { usage = 50 * 1024 * 1024, timestamp = time() }         -- 50MB now
     }
     
     -- Force leak detection
@@ -201,7 +201,7 @@ local function TestUsagePrediction()
     local memoryManager = EnhancedMemoryManager.new()
     
     -- Add enough historical data for prediction
-    local baseTime = tick()
+    local baseTime = time()
     for i = 1, 15 do
         local timeOffset = (i - 1) * 300 -- 5 minutes apart
         local usage = 10 * 1024 * 1024 + (i * 1024 * 1024) -- Growing usage
@@ -240,14 +240,14 @@ local function TestSecurityIntegration()
     memoryManager.memoryUsage.SECURITY_DATA = {
         current = 100 * 1024 * 1024, -- 100MB
         peak = 100 * 1024 * 1024,
-        lastUpdate = tick()
+        lastUpdate = time()
     }
     
     -- Add historical data showing rapid growth
     memoryManager.memoryHistory.SECURITY_DATA = {
-        { usage = 10 * 1024 * 1024, timestamp = tick() - 300 }, -- 10MB 5 min ago
-        { usage = 50 * 1024 * 1024, timestamp = tick() - 150 }, -- 50MB 2.5 min ago
-        { usage = 100 * 1024 * 1024, timestamp = tick() }       -- 100MB now
+        { usage = 10 * 1024 * 1024, timestamp = time() - 300 }, -- 10MB 5 min ago
+        { usage = 50 * 1024 * 1024, timestamp = time() - 150 }, -- 50MB 2.5 min ago
+        { usage = 100 * 1024 * 1024, timestamp = time() }       -- 100MB now
     }
     
     -- Force security pattern check
@@ -274,7 +274,7 @@ local function TestHealthScoring()
     memoryManager.memoryUsage.SYSTEM_DATA = {
         current = 30 * 1024 * 1024, -- 30MB (healthy)
         peak = 30 * 1024 * 1024,
-        lastUpdate = tick()
+        lastUpdate = time()
     }
     
     -- Calculate health score
@@ -372,7 +372,7 @@ local function TestTrendAnalysis()
     local memoryManager = EnhancedMemoryManager.new()
     
     -- Add trend data
-    local baseTime = tick()
+    local baseTime = time()
     for i = 1, 10 do
         local timeOffset = (i - 1) * 3600 -- 1 hour apart
         local usage = 20 * 1024 * 1024 + (i * 5 * 1024 * 1024) -- Growing usage
@@ -409,14 +409,14 @@ local function TestSecurityPatternDetection()
     memoryManager.memoryUsage.SECURITY_DATA = {
         current = 200 * 1024 * 1024, -- 200MB
         peak = 200 * 1024 * 1024,
-        lastUpdate = tick()
+        lastUpdate = time()
     }
     
     -- Add oscillating pattern data
     memoryManager.memoryHistory.SECURITY_DATA = {
-        { usage = 100 * 1024 * 1024, timestamp = tick() - 600 },
-        { usage = 200 * 1024 * 1024, timestamp = tick() - 300 },
-        { usage = 150 * 1024 * 1024, timestamp = tick() }
+        { usage = 100 * 1024 * 1024, timestamp = time() - 600 },
+        { usage = 200 * 1024 * 1024, timestamp = time() - 300 },
+        { usage = 150 * 1024 * 1024, timestamp = time() }
     }
     
     -- Check for suspicious patterns

--- a/test_milestone2_comprehensive.lua
+++ b/test_milestone2_comprehensive.lua
@@ -77,8 +77,8 @@ Enum = {
     KeyCode = { H = "H", P = "P" }
 }
 
--- Mock tick function
-function tick() return os.time() end
+-- Provide time() alias for environments without a global time()
+local time = time or os.time
 
 -- Mock warn and print functions
 local originalWarn = warn
@@ -322,17 +322,17 @@ local function TestPlotSwitching()
         function PlotSwitchingSystem:CanSwitch(playerId)
             local cooldownTime = self.cooldowns[playerId]
             if not cooldownTime then return true end
-            return tick() >= cooldownTime
+            return time() >= cooldownTime
         end
         
         function PlotSwitchingSystem:SetCooldown(playerId)
-            self.cooldowns[playerId] = tick() + self.plotSwitchCooldown
+            self.cooldowns[playerId] = time() + self.plotSwitchCooldown
         end
         
         function PlotSwitchingSystem:GetCooldownRemaining(playerId)
             local cooldownTime = self.cooldowns[playerId]
             if not cooldownTime then return 0 end
-            local remaining = cooldownTime - tick()
+            local remaining = cooldownTime - time()
             return math.max(0, remaining)
         end
         
@@ -377,8 +377,8 @@ local function TestDataPreservation()
             self.preservedData[tycoonId] = {
                 playerId = playerId,
                 data = data,
-                lastActiveTime = tick(),
-                lastUpdateTime = tick()
+                lastActiveTime = time(),
+                lastUpdateTime = time()
             }
         end
         
@@ -389,12 +389,12 @@ local function TestDataPreservation()
         function DataPreservationSystem:UpdateData(tycoonId, dataType, newData)
             if self.preservedData[tycoonId] then
                 self.preservedData[tycoonId].data[dataType] = newData
-                self.preservedData[tycoonId].lastUpdateTime = tick()
+                self.preservedData[tycoonId].lastUpdateTime = time()
             end
         end
         
         function DataPreservationSystem:CleanupOldData()
-            local currentTime = tick()
+            local currentTime = time()
             local cleanedCount = 0
             
             for tycoonId, data in pairs(self.preservedData) do
@@ -512,7 +512,7 @@ local function TestCompleteWorkflow()
             if not ownsTarget then return false end
             
             -- Check cooldown
-            if self.cooldowns[playerId] and tick() < self.cooldowns[playerId] then
+            if self.cooldowns[playerId] and time() < self.cooldowns[playerId] then
                 return false
             end
             
@@ -521,7 +521,7 @@ local function TestCompleteWorkflow()
             player.currentTycoon = targetTycoonId
             
             -- Set cooldown
-            self.cooldowns[playerId] = tick() + 5
+            self.cooldowns[playerId] = time() + 5
             
             return true, oldTycoon
         end
@@ -584,7 +584,7 @@ local function TestErrorHandling()
                 type = errorType,
                 message = message,
                 playerId = playerId,
-                timestamp = tick()
+                timestamp = time()
             })
         end
         
@@ -593,7 +593,7 @@ local function TestErrorHandling()
                 type = warningType,
                 message = message,
                 playerId = playerId,
-                timestamp = tick()
+                timestamp = time()
             })
         end
         
@@ -652,16 +652,16 @@ local function TestPerformanceAndMemory()
         function PerformanceSystem:StartOperation(operationName)
             return {
                 name = operationName,
-                startTime = tick()
+                startTime = time()
             }
         end
         
         function PerformanceSystem:EndOperation(operation)
-            local duration = tick() - operation.startTime
+            local duration = time() - operation.startTime
             table.insert(self.operations, {
                 name = operation.name,
                 duration = duration,
-                timestamp = tick()
+                timestamp = time()
             })
             
             if duration > self.thresholds.maxOperationTime then
@@ -674,7 +674,7 @@ local function TestPerformanceAndMemory()
         function PerformanceSystem:TrackMemoryUsage(usage)
             table.insert(self.memoryUsage, {
                 usage = usage,
-                timestamp = tick()
+                timestamp = time()
             })
             
             if usage > self.thresholds.maxMemoryUsage then

--- a/test_milestone2_roblox_studio.lua
+++ b/test_milestone2_roblox_studio.lua
@@ -228,17 +228,17 @@ local function TestPlotSwitching()
         function PlotSwitchingSystem:CanSwitch(playerId)
             local cooldownTime = self.cooldowns[playerId]
             if not cooldownTime then return true end
-            return tick() >= cooldownTime
+            return time() >= cooldownTime
         end
         
         function PlotSwitchingSystem:SetCooldown(playerId)
-            self.cooldowns[playerId] = tick() + self.plotSwitchCooldown
+            self.cooldowns[playerId] = time() + self.plotSwitchCooldown
         end
         
         function PlotSwitchingSystem:GetCooldownRemaining(playerId)
             local cooldownTime = self.cooldowns[playerId]
             if not cooldownTime then return 0 end
-            local remaining = cooldownTime - tick()
+            local remaining = cooldownTime - time()
             return math.max(0, remaining)
         end
         
@@ -284,8 +284,8 @@ local function TestDataPreservation()
             self.preservedData[tycoonId] = {
                 playerId = playerId,
                 data = data,
-                lastActiveTime = tick(),
-                lastUpdateTime = tick()
+                lastActiveTime = time(),
+                lastUpdateTime = time()
             }
         end
         
@@ -296,12 +296,12 @@ local function TestDataPreservation()
         function DataPreservationSystem:UpdateData(tycoonId, dataType, newData)
             if self.preservedData[tycoonId] then
                 self.preservedData[tycoonId].data[dataType] = newData
-                self.preservedData[tycoonId].lastUpdateTime = tick()
+                self.preservedData[tycoonId].lastUpdateTime = time()
             end
         end
         
         function DataPreservationSystem:CleanupOldData()
-            local currentTime = tick()
+            local currentTime = time()
             local cleanedCount = 0
             
             for tycoonId, data in pairs(self.preservedData) do
@@ -420,7 +420,7 @@ local function TestCompleteWorkflow()
             if not ownsTarget then return false end
             
             -- Check cooldown
-            if self.cooldowns[playerId] and tick() < self.cooldowns[playerId] then
+            if self.cooldowns[playerId] and time() < self.cooldowns[playerId] then
                 return false
             end
             
@@ -429,7 +429,7 @@ local function TestCompleteWorkflow()
             player.currentTycoon = targetTycoonId
             
             -- Set cooldown
-            self.cooldowns[playerId] = tick() + 5
+            self.cooldowns[playerId] = time() + 5
             
             return true, oldTycoon
         end

--- a/test_milestone3_improvements.lua
+++ b/test_milestone3_improvements.lua
@@ -83,7 +83,7 @@ print("    ✅ Table index validation working")
 -- Test performance monitoring
 print("  Testing performance monitoring...")
 
-local startTime = tick()
+local startTime = time()
 securityManager:LogValidationTime(startTime, "TEST_VALIDATION")
 local metrics = securityManager:GetPerformanceMetrics()
 
@@ -198,7 +198,7 @@ print("    ✅ System health monitoring working")
 -- Performance stress test
 print("🚀 Testing performance under load...")
 
-local startTime = tick()
+local startTime = time()
 local iterations = 1000
 
 for i = 1, iterations do
@@ -213,7 +213,7 @@ for i = 1, iterations do
     assert(result, "Validation should succeed for valid data")
 end
 
-local endTime = tick()
+local endTime = time()
 local duration = endTime - startTime
 local rate = iterations / duration
 

--- a/test_performance_suite_comprehensive.lua
+++ b/test_performance_suite_comprehensive.lua
@@ -82,7 +82,7 @@ local function runAutomatedTestSequence()
     
     print("🤖 Starting automated test sequence...")
     testState.isRunning = true
-    testState.startTime = tick()
+    testState.startTime = time()
     testState.testIndex = 1
     
     -- Start the first test
@@ -152,7 +152,7 @@ end
 ]]
 local function completeTestSequence()
     testState.isRunning = false
-    local totalTime = tick() - testState.startTime
+    local totalTime = time() - testState.startTime
     
     print("\n🎉 AUTOMATED TEST SEQUENCE COMPLETED!")
     print("=" .. string.rep("=", 60))
@@ -210,7 +210,7 @@ local function analyzePerformanceRegressions()
     -- For now, we'll provide a template
     
     return {
-        timestamp = tick(),
+        timestamp = time(),
         regressions = regressions,
         severity = "Low",
         recommendations = {
@@ -251,7 +251,7 @@ local function generateFinalTestSummary()
     -- Test Execution Summary
     print("\n📋 TEST EXECUTION SUMMARY")
     print("   Total Tests: " .. #TEST_CONFIG.TEST_SEQUENCE)
-    print("   Execution Time: " .. math.floor(tick() - testState.startTime) .. " seconds")
+    print("   Execution Time: " .. math.floor(time() - testState.startTime) .. " seconds")
     print("   Status: ✅ COMPLETED")
     
     -- Test Results Summary

--- a/test_step10_anime_guild_system.lua
+++ b/test_step10_anime_guild_system.lua
@@ -127,9 +127,9 @@ function testCreateAnimeGuild()
         leader = mockPlayer.UserId,
         members = {[mockPlayer.UserId] = {
             role = "LEADER",
-            joinedAt = tick(),
+            joinedAt = time(),
             contribution = 0,
-            lastActive = tick()
+            lastActive = time()
         }},
         level = 1,
         experience = 0,
@@ -179,8 +179,8 @@ function testActivateAnimeGuildBonus(guildId, bonusId)
     
     -- Check if bonus is on cooldown
     local currentBonus = GuildSystem.animeGuildBonuses[guildId] and GuildSystem.animeGuildBonuses[guildId][bonusId]
-    if currentBonus and tick() < currentBonus.expiresAt + bonus.cooldown then
-        local remainingCooldown = (currentBonus.expiresAt + bonus.cooldown) - tick()
+    if currentBonus and time() < currentBonus.expiresAt + bonus.cooldown then
+        local remainingCooldown = (currentBonus.expiresAt + bonus.cooldown) - time()
         print("❌ Error: Bonus on cooldown. Remaining time:", math.floor(remainingCooldown / 60), "minutes")
         return false
     end
@@ -193,8 +193,8 @@ function testActivateAnimeGuildBonus(guildId, bonusId)
     GuildSystem.animeGuildBonuses[guildId][bonusId] = {
         effect = bonus.effect,
         value = bonus.value,
-        activatedAt = tick(),
-        expiresAt = tick() + bonus.duration,
+        activatedAt = time(),
+        expiresAt = time() + bonus.duration,
         activatorId = mockPlayer.UserId
     }
     
@@ -243,7 +243,7 @@ function testStartAnimeGuildWar(guild1Id, guild2Id)
         guild2Id = guild2Id,
         guild1Theme = guild1.animeTheme,
         guild2Theme = guild2.animeTheme,
-        startTime = tick(),
+        startTime = time(),
         duration = 7 * 24 * 60 * 60, -- 7 days
         status = "ACTIVE",
         warType = "ANIME_WAR",
@@ -323,8 +323,8 @@ function testGenerateAnimeWarEvent(warId)
     local event = {
         id = eventId,
         type = eventType,
-        startTime = tick(),
-        expiresAt = tick() + 1800, -- 30 minutes
+        startTime = time(),
+        expiresAt = time() + 1800, -- 30 minutes
         status = "ACTIVE",
         participants = {},
         rewards = calculateAnimeWarEventRewards(eventType)
@@ -391,7 +391,7 @@ function testGetAnimeGuildStats(guildId)
     local guildBonuses = GuildSystem.animeGuildBonuses[guildId]
     if guildBonuses then
         for bonusId, bonus in pairs(guildBonuses) do
-            if tick() < bonus.expiresAt then
+            if time() < bonus.expiresAt then
                 stats.activeBonuses[bonusId] = bonus
             end
         end
@@ -444,9 +444,9 @@ function runStep10Tests()
         leader = mockTargetPlayer.UserId,
         members = {[mockTargetPlayer.UserId] = {
             role = "LEADER",
-            joinedAt = tick(),
+            joinedAt = time(),
             contribution = 0,
-            lastActive = tick()
+            lastActive = time()
         }},
         level = 1,
         experience = 0,
@@ -495,7 +495,7 @@ function runStep10Tests()
     local totalActiveBonuses = 0
     for guildId, bonuses in pairs(GuildSystem.animeGuildBonuses) do
         for _, bonus in pairs(bonuses) do
-            if tick() < bonus.expiresAt then
+            if time() < bonus.expiresAt then
                 totalActiveBonuses = totalActiveBonuses + 1
             end
         end

--- a/test_step10_comprehensive_anime_guild.lua
+++ b/test_step10_comprehensive_anime_guild.lua
@@ -164,9 +164,9 @@ function testCreateAnimeGuild(leader, guildName, description, tag, animeTheme)
         leader = leader.UserId,
         members = {[leader.UserId] = {
             role = "LEADER",
-            joinedAt = tick(),
+            joinedAt = time(),
             contribution = 0,
-            lastActive = tick()
+            lastActive = time()
         }},
         level = 1,
         experience = 0,
@@ -218,8 +218,8 @@ function testActivateAnimeGuildBonus(guildId, bonusId)
 
     -- Check if bonus is on cooldown
     local currentBonus = GuildSystem.animeGuildBonuses[guildId] and GuildSystem.animeGuildBonuses[guildId][bonusId]
-    if currentBonus and tick() < currentBonus.expiresAt + bonus.cooldown then
-        local remainingCooldown = (currentBonus.expiresAt + bonus.cooldown) - tick()
+    if currentBonus and time() < currentBonus.expiresAt + bonus.cooldown then
+        local remainingCooldown = (currentBonus.expiresAt + bonus.cooldown) - time()
         print("❌ Error: Bonus on cooldown. Remaining time:", math.floor(remainingCooldown / 60), "minutes")
         return false
     end
@@ -232,8 +232,8 @@ function testActivateAnimeGuildBonus(guildId, bonusId)
     GuildSystem.animeGuildBonuses[guildId][bonusId] = {
         effect = bonus.effect,
         value = bonus.value,
-        activatedAt = tick(),
-        expiresAt = tick() + bonus.duration,
+        activatedAt = time(),
+        expiresAt = time() + bonus.duration,
         activatorId = guild.leader
     }
 
@@ -282,7 +282,7 @@ function testStartAnimeGuildWar(guild1Id, guild2Id)
         guild2Id = guild2Id,
         guild1Theme = guild1.animeTheme,
         guild2Theme = guild2.animeTheme,
-        startTime = tick(),
+        startTime = time(),
         duration = 7 * 24 * 60 * 60, -- 7 days
         status = "ACTIVE",
         warType = "ANIME_WAR",
@@ -357,7 +357,7 @@ function testCreateCrossAnimeCollaboration(guild1Id, guild2Id, collaborationType
         guild1Theme = guild1.animeTheme,
         guild2Theme = guild2.animeTheme,
         type = collaborationType,
-        startTime = tick(),
+        startTime = time(),
         duration = 3 * 24 * 60 * 60, -- 3 days
         status = "ACTIVE",
         participants = {
@@ -411,7 +411,7 @@ function testCreateAnimeFestival(guildId, festivalType, data)
         type = festivalType,
         data = data,
         creatorId = guild.leader,
-        startTime = tick(),
+        startTime = time(),
         duration = 24 * 60 * 60, -- 24 hours
         status = "ACTIVE",
         participants = {},
@@ -460,8 +460,8 @@ function testGenerateAnimeWarEvent(warId)
     local event = {
         id = eventId,
         type = eventType,
-        startTime = tick(),
-        expiresAt = tick() + 1800, -- 30 minutes
+        startTime = time(),
+        expiresAt = time() + 1800, -- 30 minutes
         status = "ACTIVE",
         participants = {},
         rewards = calculateAnimeWarEventRewards(eventType)
@@ -504,8 +504,8 @@ function testGenerateCrossAnimeCollaborationEvent(collaborationId)
     local event = {
         id = eventId,
         type = eventType,
-        startTime = tick(),
-        expiresAt = tick() + 1800, -- 30 minutes
+        startTime = time(),
+        expiresAt = time() + 1800, -- 30 minutes
         status = "ACTIVE",
         participants = {},
         rewards = calculateCrossAnimeCollaborationEventRewards(eventType)
@@ -549,8 +549,8 @@ function testGenerateAnimeFestivalEvent(festivalId)
     local event = {
         id = eventId,
         type = eventType,
-        startTime = tick(),
-        expiresAt = tick() + 900, -- 15 minutes
+        startTime = time(),
+        expiresAt = time() + 900, -- 15 minutes
         status = "ACTIVE",
         participants = {},
         rewards = calculateAnimeFestivalEventRewards(eventType)
@@ -597,7 +597,7 @@ function testGetComprehensiveAnimeGuildStats(guildId)
     local guildBonuses = GuildSystem.animeGuildBonuses[guildId]
     if guildBonuses then
         for bonusId, bonus in pairs(guildBonuses) do
-            if tick() < bonus.expiresAt then
+            if time() < bonus.expiresAt then
                 stats.activeBonuses[bonusId] = bonus
             end
         end
@@ -898,7 +898,7 @@ function runComprehensiveStep10Tests()
     local totalActiveBonuses = 0
     for guildId, bonuses in pairs(GuildSystem.animeGuildBonuses) do
         for _, bonus in pairs(bonuses) do
-            if tick() < bonus.expiresAt then
+            if time() < bonus.expiresAt then
                 totalActiveBonuses = totalActiveBonuses + 1
             end
         end

--- a/test_step13_network_manager_integration.lua
+++ b/test_step13_network_manager_integration.lua
@@ -104,7 +104,7 @@ local status = NetworkManager:GetAnimeNetworkingStatus()
 print("Total anime events:", status.totalAnimeEvents)
 print("Active connections:", status.activeAnimeConnections)
 print("Event queue:", status.animeEventQueue)
-print("Last sync:", math.floor(tick() - status.lastAnimeSync), "seconds ago")
+print("Last sync:", math.floor(time() - status.lastAnimeSync), "seconds ago")
 
 if status.totalAnimeEvents >= 25 then
     print("✅ Anime networking status shows comprehensive coverage")

--- a/test_step1_implementation.lua
+++ b/test_step1_implementation.lua
@@ -158,12 +158,12 @@ print("✅ Full integration with existing systems")
 print(string.rep("=", 72))
 
 -- Performance test
-local startTime = tick()
+local startTime = time()
 for i = 1, 1000 do
     Constants.GetAnimeTheme("NARUTO")
     Constants.GetPlotPosition(i % 20 + 1)
 end
-local endTime = tick()
+local endTime = time()
 local performanceTime = (endTime - startTime) * 1000
 
 print(string.format("\n⚡ Performance Test: 1000 operations in %.2f ms", performanceTime))

--- a/test_step8_implementation.lua
+++ b/test_step8_implementation.lua
@@ -237,10 +237,10 @@ print("\n📋 **Test 7: Performance Features**")
 print("-" .. string.rep("-", 40))
 
 -- Test cached calculations
-local startTime = tick()
+local startTime = time()
 local stats1 = collection:GetCollectionStats()
 local stats2 = collection:GetCollectionStats()
-local endTime = tick()
+local endTime = time()
 
 assert(stats1.totalCards == stats2.totalCards, "Cached calculations should be consistent")
 assert(endTime - startTime < 0.1, "Cached calculations should be fast")

--- a/tests/QuickTest.lua
+++ b/tests/QuickTest.lua
@@ -150,7 +150,7 @@ end)
 
 -- Test 6: Performance Check
 runTest("Performance Check", function()
-    local startTime = tick()
+    local startTime = time()
     
     -- Simulate some work
     local sum = 0
@@ -158,7 +158,7 @@ runTest("Performance Check", function()
         sum = sum + i
     end
     
-    local endTime = tick()
+    local endTime = time()
     local duration = endTime - startTime
     
     print("   Basic computation took", string.format("%.4f", duration * 1000), "ms")

--- a/tests/RunTests.lua
+++ b/tests/RunTests.lua
@@ -209,7 +209,7 @@ local success, TestRunner = pcall(function()
         
         -- Test 6: Performance check
         local test6Success = pcall(function()
-            local startTime = tick()
+            local startTime = time()
             
             -- Simulate some work
             local sum = 0
@@ -217,7 +217,7 @@ local success, TestRunner = pcall(function()
                 sum = sum + i
             end
             
-            local endTime = tick()
+            local endTime = time()
             local duration = endTime - startTime
             
             print("   Basic computation took", string.format("%.4f", duration * 1000), "ms")

--- a/tests/SimpleRunTests.lua
+++ b/tests/SimpleRunTests.lua
@@ -151,12 +151,12 @@ end
 
 -- Test 5: Performance
 print("\n🧪 Test 5: Performance")
-local startTime = tick()
+local startTime = time()
 local sum = 0
 for i = 1, 1000 do
     sum = sum + i
 end
-local endTime = tick()
+local endTime = time()
 local duration = endTime - startTime
 
 print("✅ Basic computation test completed")

--- a/tests/TestRunner.lua
+++ b/tests/TestRunner.lua
@@ -29,7 +29,7 @@ function TestRunner:RunAllTests()
         totalTests = 0,
         passedTests = 0,
         failedTests = 0,
-        startTime = tick()
+        startTime = time()
     }
     
     print("Starting comprehensive test execution...")
@@ -141,12 +141,12 @@ function TestRunner:RunAllTests()
     results.totalTests = results.totalTests + 1
     print("\n🧪 Test 6: Performance")
     local success6 = pcall(function()
-        local startTime = tick()
+        local startTime = time()
         local sum = 0
         for i = 1, 1000 do
             sum = sum + i
         end
-        local endTime = tick()
+        local endTime = time()
         local duration = endTime - startTime
         print("   Computation time:", string.format("%.4f", duration * 1000), "ms")
         print("   Result:", sum, "(expected: 500500)")
@@ -203,7 +203,7 @@ function TestRunner:RunAllTests()
     end
     
     -- Final Results
-    results.endTime = tick()
+    results.endTime = time()
     local executionTime = results.endTime - results.startTime
     local successRate = (results.passedTests / results.totalTests) * 100
     

--- a/tests/TestRunnerNew.lua
+++ b/tests/TestRunnerNew.lua
@@ -25,7 +25,7 @@ function TestRunnerNew:RunAllTests()
         totalTests = 0,
         passedTests = 0,
         failedTests = 0,
-        startTime = tick()
+        startTime = time()
     }
     
     print("Starting tests with NEW TestRunner...")
@@ -100,12 +100,12 @@ function TestRunnerNew:RunAllTests()
     results.totalTests = results.totalTests + 1
     print("\n🧪 Test 4: Performance")
     local success4 = pcall(function()
-        local startTime = tick()
+        local startTime = time()
         local sum = 0
         for i = 1, 1000 do
             sum = sum + i
         end
-        local endTime = tick()
+        local endTime = time()
         local duration = endTime - startTime
         print("   Time:", string.format("%.4f", duration * 1000), "ms")
         print("   Result:", sum, "(expected: 500500)")
@@ -121,7 +121,7 @@ function TestRunnerNew:RunAllTests()
     end
     
     -- Results
-    results.endTime = tick()
+    results.endTime = time()
     local executionTime = results.endTime - results.startTime
     local successRate = (results.passedTests / results.totalTests) * 100
     


### PR DESCRIPTION
## Summary
- Replace deprecated `tick()` usages with `time()` across game modules and test scripts
- Provide fallback aliases for `time()` in standalone testing environments

## Testing
- `lua tests/RunTests.lua` *(fails: attempt to call a nil value (global 'wait'))*

------
https://chatgpt.com/codex/tasks/task_b_689960c080d08322afa58fc9fb709113