### PR TITLE
refactor: centralize player join handling

### DIFF
--- a/src/Multiplayer/PlayerSync.lua
+++ b/src/Multiplayer/PlayerSync.lua
@@ -34,21 +34,21 @@ end
 
 -- Set up player event handlers
 function PlayerSync:SetupPlayerHandlers()
+    local function handlePlayer(player)
+        self:InitializePlayer(player)
+    end
+
+    -- Handle existing players
+    for _, player in ipairs(Players:GetPlayers()) do
+        handlePlayer(player)
+    end
+
     -- Player joining
-    Players.PlayerAdded:Connect(function(player)
-        self:OnPlayerJoin(player)
-    end)
-    
+    Players.PlayerAdded:Connect(handlePlayer)
+
     -- Player leaving
     Players.PlayerRemoving:Connect(function(player)
         self:OnPlayerLeave(player)
-    end)
-    
-    -- Character added
-    Players.PlayerAdded:Connect(function(player)
-        player.CharacterAdded:Connect(function(character)
-            self:OnCharacterAdded(player, character)
-        end)
     end)
 end
 

--- a/src/Server/MainServer.lua
+++ b/src/Server/MainServer.lua
@@ -782,14 +782,8 @@ end
 -- Handle player joining
 function MainServer:HandlePlayerJoined(player)
     print("MainServer: Player " .. player.Name .. " joined the game")
-    
-    -- Initialize player through PlayerSync
-    if gameState.playerSync then
-        gameState.playerSync:InitializePlayer(player)
-    end
-    
-    -- Player will be handled by HubManager for spawning and plot assignment
-    print("MainServer: Player " .. player.Name .. " initialized successfully")
+    -- PlayerSync now manages player initialization internally
+    print("MainServer: Player " .. player.Name .. " initialization deferred to PlayerSync")
 end
 
 -- Handle player leaving


### PR DESCRIPTION
## Summary
- handle existing players and new joins through a single `Players.PlayerAdded` connection
- defer join initialization to `PlayerSync` from `MainServer`

## Testing
- `lua tests/QuickTest.lua` (fails: Game should exist, attempt to index local 'parent', attempt to index global 'game', attempt to call global 'tick', attempt to index global 'Instance')

------
https://chatgpt.com/codex/tasks/task_b_689960a457bc8322a482af8c65847197