### PR TITLE
refactor: use GetPartBoundsInBox for wall repair

### DIFF
--- a/src/Player/PlayerAbilities.lua
+++ b/src/Player/PlayerAbilities.lua
@@ -419,13 +419,12 @@ function PlayerAbilities:CreateWallRepairEffect(level)
         local playerPos = self.humanoidRootPart.Position
         
         -- Find walls within radius
-        for _, obj in pairs(workspace:GetPartBoundsInRegion(
-            Region3.new(
-                playerPos - Vector3.new(repairRadius, repairRadius, repairRadius),
-                playerPos + Vector3.new(repairRadius, repairRadius, repairRadius)
-            ),
-            math.huge
-        )) do
+        local boxSize = Vector3.new(repairRadius, repairRadius, repairRadius) * 2
+        local boxCFrame = CFrame.new(playerPos)
+        local overlapParams = OverlapParams.new()
+        overlapParams.MaxParts = math.huge
+
+        for _, obj in pairs(workspace:GetPartBoundsInBox(boxCFrame, boxSize, overlapParams)) do
             if obj.Name:match("Wall") and obj:FindFirstChild("WallData") then
                 local wallData = obj.WallData
                 if wallData.Value < 100 then


### PR DESCRIPTION
## Summary
- replace deprecated region query with `workspace:GetPartBoundsInBox`
- use `CFrame` and `OverlapParams` to search nearby walls

## Testing
- `luac -p src/Player/PlayerAbilities.lua`

------
https://chatgpt.com/codex/tasks/task_b_689960947d408322a089e5c59cbacb26