### PR TITLE
Add timeouts and nil checks for character parts

### DIFF
--- a/src/Player/PlayerController.lua
+++ b/src/Player/PlayerController.lua
@@ -76,15 +76,20 @@ end
 -- Handle character added
 function PlayerController:OnCharacterAdded(character)
     self.character = character
-    self.humanoid = character:WaitForChild("Humanoid")
-    self.humanoidRootPart = character:WaitForChild("HumanoidRootPart")
-    
+    self.humanoid = character:WaitForChild("Humanoid", 10)
+    self.humanoidRootPart = character:WaitForChild("HumanoidRootPart", 10)
+
+    if not self.humanoid or not self.humanoidRootPart then
+        warn("PlayerController: Failed to load character parts for", self.player.Name)
+        return
+    end
+
     -- Set up character properties
     self:SetupCharacter()
-    
+
     -- Connect to character events
     self:ConnectToCharacter()
-    
+
     -- Apply player data
     self:ApplyPlayerData()
 end


### PR DESCRIPTION
## Summary
- add timeouts when waiting for HumanoidRootPart
- warn and exit early if essential character parts are missing

## Testing
- `lua tests/RunTests.lua` *(fails: attempt to call a nil value 'wait')*

------
https://chatgpt.com/codex/tasks/task_b_6899654b4ed083228b52a7cb978bd71c