### PR TITLE
Replace Debris respawn scheduling with task.delay

### DIFF
--- a/src/Player/PlayerController.lua
+++ b/src/Player/PlayerController.lua
@@ -169,9 +169,9 @@ function PlayerController:OnPlayerDied()
     HelperFunctions.CreateNotification(self.player, "You died! Respawning in " .. Constants.PLAYER.RESPAWN_TIME .. " seconds...", 3)
     
     -- Schedule respawn
-    game:GetService("Debris"):AddItem(function()
+    task.delay(Constants.PLAYER.RESPAWN_TIME, function()
         self:RespawnPlayer()
-    end, Constants.PLAYER.RESPAWN_TIME)
+    end)
 end
 
 -- Handle health change


### PR DESCRIPTION
## Summary
- Use `task.delay` to schedule player respawn instead of `Debris:AddItem`

## Testing
- `lua tests/RunTests.lua` *(fails: attempt to call a nil value (global 'wait'))*

------
https://chatgpt.com/codex/tasks/task_b_6899654f34f88322991202d645ad9b98