### PR TITLE
Set character PrimaryPart and tween via CFrame

### DIFF
--- a/src/Tycoon/CharacterSpawner.lua
+++ b/src/Tycoon/CharacterSpawner.lua
@@ -526,6 +526,8 @@ function CharacterSpawner:CreateCharacterInstance(character, position)
     body.Material = Enum.Material.Neon
     body.BrickColor = BrickColor.new("Bright blue")
     body.Parent = model
+    -- Make the body the primary part so the model can be positioned as a whole
+    model.PrimaryPart = body
     
     -- Apply rarity color
     body.Color = character.rarity.color
@@ -567,7 +569,10 @@ function CharacterSpawner:CreateCharacterInstance(character, position)
     
     -- Add floating effect
     local tweenInfo = TweenInfo.new(2, Enum.EasingStyle.Sine, Enum.EasingDirection.InOut, -1, true)
-    local tween = TweenService:Create(model, tweenInfo, {Position = position + Vector3.new(0, 0.5, 0)})
+    -- Tween the model's primary part upward slightly to create a floating effect
+    local tween = TweenService:Create(model.PrimaryPart, tweenInfo, {
+        CFrame = model.PrimaryPart.CFrame + Vector3.new(0, 0.5, 0)
+    })
     tween:Play()
     
     -- Set lifetime


### PR DESCRIPTION
## Summary
- assign body as character model's PrimaryPart for model movement
- use CFrame-based tween on PrimaryPart to float model

## Testing
- `lua tests/RunTests.lua` (fails: attempt to call a nil value 'wait')

------
https://chatgpt.com/codex/tasks/task_b_68996558a6688322a5aafc5736e4a655