### PR TITLE
Handle missing PrimaryPart in character effects

### DIFF
--- a/src/Tycoon/CharacterSpawner.lua
+++ b/src/Tycoon/CharacterSpawner.lua
@@ -634,11 +634,18 @@ end
 -- Process character spawn effects
 function CharacterSpawner:ProcessCharacterSpawnEffects(characterData)
     if characterData.instance then
+        -- Determine reference part for effect positioning
+        local primaryPart = characterData.instance.PrimaryPart
+            or characterData.instance:FindFirstChild("Body")
+        if not primaryPart then
+            return
+        end
+
         -- Add spawn particle effect
         local spawnEffect = Instance.new("Part")
         spawnEffect.Name = "SpawnEffect"
         spawnEffect.Size = Vector3.new(1, 1, 1)
-        spawnEffect.Position = characterData.instance.PrimaryPart.Position
+        spawnEffect.Position = primaryPart.Position
         spawnEffect.Anchored = true
         spawnEffect.Material = Enum.Material.Neon
         spawnEffect.Color = characterData.data.rarity.color
@@ -661,11 +668,18 @@ end
 -- Process character despawn effects
 function CharacterSpawner:ProcessCharacterDespawnEffects(characterData)
     if characterData.instance then
+        -- Determine reference part for effect positioning
+        local primaryPart = characterData.instance.PrimaryPart
+            or characterData.instance:FindFirstChild("Body")
+        if not primaryPart then
+            return
+        end
+
         -- Add despawn particle effect
         local despawnEffect = Instance.new("Part")
         despawnEffect.Name = "DespawnEffect"
         despawnEffect.Size = Vector3.new(1, 1, 1)
-        despawnEffect.Position = characterData.instance.PrimaryPart.Position
+        despawnEffect.Position = primaryPart.Position
         despawnEffect.Anchored = true
         despawnEffect.Material = Enum.Material.Neon
         despawnEffect.Color = Color3.new(1, 0, 0) -- Red for despawn


### PR DESCRIPTION
## Summary
- Avoid errors when character instance lacks `PrimaryPart` by using `Body` fallback or skipping effect creation

## Testing
- `lua tests/RunTests.lua` *(fails: attempt to call global 'wait')*

------
https://chatgpt.com/codex/tasks/task_b_6899655c107c83228b2226ac00e13863