### PR TITLE
Store sync heartbeat connection

### DIFF
--- a/src/Multiplayer/TycoonSync.lua
+++ b/src/Multiplayer/TycoonSync.lua
@@ -282,27 +282,28 @@ end
 
 -- Start all sync loops
 function TycoonSync:StartSyncLoops()
-    -- Main tycoon sync loop
-    RunService.Heartbeat:Connect(function()
+    -- Disconnect existing sync connection if it exists
+    if self.syncConnection then
+        self.syncConnection:Disconnect()
+        self.syncConnection = nil
+    end
+
+    -- Main tycoon sync and cash generation loop
+    self.syncConnection = RunService.Heartbeat:Connect(function()
         local currentTime = time()
-        
+
         for tycoonId, lastSync in pairs(lastSyncTime) do
             if currentTime - lastSync >= TYCOON_SYNC_INTERVAL then
                 self:SyncTycoonData(tycoonId)
             end
         end
-    end)
-    
-    -- Cash generation loop
-    RunService.Heartbeat:Connect(function()
-        local currentTime = time()
-        
+
         for tycoonId, data in pairs(tycoonData) do
             if data.Owner and data.IsActive then
                 -- Generate cash based on level and upgrades
                 local cashPerSecond = data.CashGeneratorLevel * 10
                 local timeSinceLastGen = currentTime - data.LastCashGeneration
-                
+
                 if timeSinceLastGen >= 1.0 then
                     local cashGenerated = cashPerSecond * timeSinceLastGen
                     self:UpdateTycoonCash(tycoonId, cashGenerated)


### PR DESCRIPTION
## Summary
- Save RunService.Heartbeat connection in `self.syncConnection`
- Disconnect and nil existing connection before creating a new one

## Testing
- `lua tests/RunTests.lua` *(fails: attempt to call global 'wait')*

------
https://chatgpt.com/codex/tasks/task_b_68996556c5708322aa306796f48800d2