### PR TITLE
Cache player data after initialization

### DIFF
--- a/src/Multiplayer/PlayerSync.lua
+++ b/src/Multiplayer/PlayerSync.lua
@@ -62,13 +62,22 @@ function PlayerSync:OnPlayerJoin(player)
         local PlayerData = require(ReplicatedStorage:WaitForChild("Player"):WaitForChild("PlayerData"))
         return PlayerData.GetPlayerData(player)
     end)
-    
+
     if success and playerDataInstance then
         -- Player data already exists or was created successfully
         print("PlayerSync: Player data initialized for", player.Name)
+
+        -- Cache serializable snapshot for sync operations
+        if playerDataInstance.GetSerializableData then
+            playerData[player.UserId] = playerDataInstance:GetSerializableData()
+        elseif playerDataInstance.GetAllData then
+            playerData[player.UserId] = playerDataInstance:GetAllData()
+        else
+            playerData[player.UserId] = {}
+        end
     else
         warn("PlayerSync: Failed to initialize player data for", player.Name, "- falling back to basic data")
-        
+
         -- Fallback to basic data structure
         playerData[player.UserId] = {
             Position = Vector3.new(0, 0, 0),

--- a/src/Player/PlayerData.lua
+++ b/src/Player/PlayerData.lua
@@ -341,6 +341,23 @@ function PlayerData:GetAllData()
     return table.clone(self.data)
 end
 
+-- Get serializable snapshot of player state for networking
+function PlayerData:GetSerializableData()
+    local character = self.player and self.player.Character
+    local humanoid = character and character:FindFirstChild("Humanoid")
+    local humanoidRootPart = character and character:FindFirstChild("HumanoidRootPart")
+
+    return {
+        Position = humanoidRootPart and humanoidRootPart.Position or Vector3.new(0, 0, 0),
+        Rotation = humanoidRootPart and Vector3.new(0, humanoidRootPart.Orientation.Y, 0) or Vector3.new(0, 0, 0),
+        Health = humanoid and humanoid.Health or 100,
+        MaxHealth = humanoid and humanoid.MaxHealth or 100,
+        Abilities = self:GetAllAbilities(),
+        CurrentTycoon = self:GetCurrentTycoon(),
+        LastUpdate = time(),
+    }
+end
+
 -- Load player data
 function PlayerData:LoadData(data)
     if type(data) == "table" then


### PR DESCRIPTION
## Summary
- Cache serialized player data after a successful PlayerData lookup
- Provide `GetSerializableData` helper to obtain a snapshot of player state for syncing

## Testing
- `luac -p src/Multiplayer/PlayerSync.lua`
- `luac -p src/Player/PlayerData.lua`


------
https://chatgpt.com/codex/tasks/task_b_6899655517208322a218c8b1e7627e56